### PR TITLE
Feature/mtic 2710 tags support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,18 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 gemspec
 
-gem "rails", "~> #{ENV["RAILS_VERSION"] || '4.2.5'}"
-gem "sqlite3", "~> 1.3.7"
-gem "minitest", "~> 5.10.3"
-gem "rake", "~> 10.0.4"
-gem "test-unit", "~> 3.0"
+gem 'minitest', '~> 5.10.3'
+gem 'rails', "~> #{ENV['RAILS_VERSION'] || '4.2.5'}"
+gem 'rake', '~> 10.0.4'
+gem 'sqlite3', '~> 1.3.7'
+gem 'test-unit', '~> 3.0'
 
 group :watch do
-  gem "rb-fsevent", "~> 0.9.3", require: false
+  gem 'rb-fsevent', '~> 0.9.3', require: false
 end
 
 group :bench do
-  gem "rblineprof", "~> 0.3.6"
+  gem 'rblineprof', '~> 0.3.6'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
 #!/usr/bin/env rake
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
 
-require "rake/testtask"
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+
+require 'rake/testtask'
 Rake::TestTask.new do |t|
-  t.libs = ["lib", "test"]
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.libs = %w[lib test]
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :test
+task default: :test

--- a/lib/nunes.rb
+++ b/lib/nunes.rb
@@ -42,11 +42,14 @@ module Nunes
   NAMESPACE_SEPARATOR = "::".freeze
 
   # Private: What nunes uses to separate namespaces in the metric.
-  METRIC_NAMESPACE_SEPARATOR = "-".freeze
+  METRIC_NAMESPACE_SEPARATOR = "_".freeze
 
   # Private: Converts a class to a metric safe name.
   def self.class_to_metric(class_or_class_name)
     return if class_or_class_name.nil?
-    class_or_class_name.to_s.gsub(NAMESPACE_SEPARATOR, METRIC_NAMESPACE_SEPARATOR)
+    class_or_class_name.
+      to_s.
+      gsub(NAMESPACE_SEPARATOR, METRIC_NAMESPACE_SEPARATOR).
+      underscore
   end
 end

--- a/lib/nunes.rb
+++ b/lib/nunes.rb
@@ -1,16 +1,18 @@
-require "nunes/instrumentable"
+# frozen_string_literal: true
 
-require "nunes/adapters/memory"
-require "nunes/adapters/timing_aliased"
+require 'nunes/instrumentable'
 
-require "nunes/subscriber"
-require "nunes/subscribers/action_controller"
-require "nunes/subscribers/action_view"
-require "nunes/subscribers/action_mailer"
-require "nunes/subscribers/active_support"
-require "nunes/subscribers/active_record"
-require "nunes/subscribers/active_job"
-require "nunes/subscribers/nunes"
+require 'nunes/adapters/memory'
+require 'nunes/adapters/timing_aliased'
+
+require 'nunes/subscriber'
+require 'nunes/subscribers/action_controller'
+require 'nunes/subscribers/action_view'
+require 'nunes/subscribers/action_mailer'
+require 'nunes/subscribers/active_support'
+require 'nunes/subscribers/active_record'
+require 'nunes/subscribers/active_job'
+require 'nunes/subscribers/nunes'
 
 module Nunes
   # Public: Shortcut method to setup all subscribers for a given client.
@@ -39,17 +41,18 @@ module Nunes
   end
 
   # Private: What ruby uses to separate namespaces.
-  NAMESPACE_SEPARATOR = "::".freeze
+  NAMESPACE_SEPARATOR = '::'
 
   # Private: What nunes uses to separate namespaces in the metric.
-  METRIC_NAMESPACE_SEPARATOR = "_".freeze
+  METRIC_NAMESPACE_SEPARATOR = '_'
 
   # Private: Converts a class to a metric safe name.
   def self.class_to_metric(class_or_class_name)
     return if class_or_class_name.nil?
-    class_or_class_name.
-      to_s.
-      gsub(NAMESPACE_SEPARATOR, METRIC_NAMESPACE_SEPARATOR).
-      underscore
+
+    class_or_class_name
+      .to_s
+      .gsub(NAMESPACE_SEPARATOR, METRIC_NAMESPACE_SEPARATOR)
+      .underscore
   end
 end

--- a/lib/nunes/adapter.rb
+++ b/lib/nunes/adapter.rb
@@ -43,14 +43,14 @@ module Nunes
 
     # Internal: Increment a metric by a value. Override in subclass if client
     # interface does not match.
-    def increment(metric, value = 1)
-      @client.increment prepare(metric), value
+    def increment(stat, opts={})
+      @client.increment prepare(stat), opts
     end
 
     # Internal: Record a metric's duration. Override in subclass if client
     # interface does not match.
-    def timing(metric, duration)
-      @client.timing prepare(metric), duration
+    def timing(stat, msec, opts={})
+      @client.timing prepare(stat), msec, opts
     end
 
     # Private: What Ruby uses to separate namespaces.

--- a/lib/nunes/adapter.rb
+++ b/lib/nunes/adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/class/subclasses'
 
 module Nunes
@@ -8,14 +10,14 @@ module Nunes
     #
     # Returns Nunes::Adapter instance.
     def self.wrap(client)
-      raise ArgumentError, "client cannot be nil" if client.nil?
+      raise ArgumentError, 'client cannot be nil' if client.nil?
       return client if client.is_a?(self)
 
       adapter = adapters.detect { |adapter| adapter.wraps?(client) }
 
       if adapter.nil?
         raise ArgumentError,
-          "I have no clue how to wrap what you've given me (#{client.inspect})"
+              "I have no clue how to wrap what you've given me (#{client.inspect})"
       end
 
       adapter.new(client)
@@ -43,24 +45,24 @@ module Nunes
 
     # Internal: Increment a metric by a value. Override in subclass if client
     # interface does not match.
-    def increment(stat, opts={})
+    def increment(stat, opts = {})
       @client.increment prepare(stat), opts
     end
 
     # Internal: Record a metric's duration. Override in subclass if client
     # interface does not match.
-    def timing(stat, msec, opts={})
+    def timing(stat, msec, opts = {})
       @client.timing prepare(stat), msec, opts
     end
 
     # Private: What Ruby uses to separate namespaces.
-    ReplaceRegex = /[^a-z0-9\-_]+/i
+    ReplaceRegex = /[^a-z0-9\-_]+/i.freeze
 
     # Private: The default metric namespace separator.
-    Separator = ".".freeze
+    Separator = '.'
 
     # Private
-    Nothing = "".freeze
+    Nothing = ''
 
     # Private: Prepare a metric name before it is sent to the adapter's client.
     def prepare(metric, replacement = Separator)

--- a/lib/nunes/adapters/memory.rb
+++ b/lib/nunes/adapters/memory.rb
@@ -17,7 +17,7 @@ module Nunes
       end
 
       def increment(stat, opts = {})
-        counters << [prepare(stat), 1, opts]
+        counters << [prepare(stat), opts]
       end
 
       def timing(stat, msec, opts = {})
@@ -35,8 +35,11 @@ module Nunes
       end
 
       # Internal: Returns true/false if metric has been recorded as a timer.
-      def timer?(metric)
-        timers.detect { |op| op.first == metric }
+      def timer?(metric, opts = {})
+        timers.detect do |op|
+          op.first == metric &&
+            op.last == opts
+        end
       end
 
       # Internal: Returns Array of any recorded counters with values.
@@ -50,8 +53,11 @@ module Nunes
       end
 
       # Internal: Returns true/false if metric has been recorded as a counter.
-      def counter?(metric, opts = { sample_rate: 1, tags: {} })
-        counters.detect { |op| op.first == metric && op.last[:tags] == opts[:tags] }
+      def counter?(metric, opts = {})
+        counters.detect do |op|
+          op.first == metric &&
+            op.last == opts
+        end
       end
 
       # Internal: Empties the known counters and metrics.

--- a/lib/nunes/adapters/memory.rb
+++ b/lib/nunes/adapters/memory.rb
@@ -14,12 +14,12 @@ module Nunes
         clear
       end
 
-      def increment(metric, value = 1)
-        counters << [prepare(metric), value]
+      def increment(stat, opts={})
+        counters << [prepare(stat), 1, opts]
       end
 
-      def timing(metric, value)
-        timers << [prepare(metric), value]
+      def timing(stat, msec, opts={})
+        timers << [prepare(stat), msec, opts]
       end
 
       # Internal: Returns Array of any recorded timers with durations.
@@ -48,8 +48,8 @@ module Nunes
       end
 
       # Internal: Returns true/false if metric has been recorded as a counter.
-      def counter?(metric)
-        counters.detect { |op| op.first == metric }
+      def counter?(metric, opts = { sample_rate: 1, tags: {}})
+        counters.detect { |op| op.first == metric && op.last[:tags] == opts[:tags]}
       end
 
       # Internal: Empties the known counters and metrics.

--- a/lib/nunes/adapters/memory.rb
+++ b/lib/nunes/adapters/memory.rb
@@ -1,4 +1,6 @@
-require "nunes/adapter"
+# frozen_string_literal: true
+
+require 'nunes/adapter'
 
 module Nunes
   module Adapters
@@ -14,11 +16,11 @@ module Nunes
         clear
       end
 
-      def increment(stat, opts={})
+      def increment(stat, opts = {})
         counters << [prepare(stat), 1, opts]
       end
 
-      def timing(stat, msec, opts={})
+      def timing(stat, msec, opts = {})
         timers << [prepare(stat), msec, opts]
       end
 
@@ -29,7 +31,7 @@ module Nunes
 
       # Internal: Returns Array of only recorded timers.
       def timer_metric_names
-        timers.map { |op| op.first }
+        timers.map(&:first)
       end
 
       # Internal: Returns true/false if metric has been recorded as a timer.
@@ -44,12 +46,12 @@ module Nunes
 
       # Internal: Returns Array of only recorded counters.
       def counter_metric_names
-        counters.map { |op| op.first }
+        counters.map(&:first)
       end
 
       # Internal: Returns true/false if metric has been recorded as a counter.
-      def counter?(metric, opts = { sample_rate: 1, tags: {}})
-        counters.detect { |op| op.first == metric && op.last[:tags] == opts[:tags]}
+      def counter?(metric, opts = { sample_rate: 1, tags: {} })
+        counters.detect { |op| op.first == metric && op.last[:tags] == opts[:tags] }
       end
 
       # Internal: Empties the known counters and metrics.

--- a/lib/nunes/adapters/timing_aliased.rb
+++ b/lib/nunes/adapters/timing_aliased.rb
@@ -1,4 +1,6 @@
-require "nunes/adapter"
+# frozen_string_literal: true
+
+require 'nunes/adapter'
 
 module Nunes
   module Adapters
@@ -15,7 +17,7 @@ module Nunes
       end
 
       # Internal: Adapter timing to gauge.
-      def timing(stat, msec, opts={})
+      def timing(stat, msec, opts = {})
         @client.gauge prepare(stat), msec, opts
       end
     end

--- a/lib/nunes/adapters/timing_aliased.rb
+++ b/lib/nunes/adapters/timing_aliased.rb
@@ -15,8 +15,8 @@ module Nunes
       end
 
       # Internal: Adapter timing to gauge.
-      def timing(metric, duration)
-        @client.gauge prepare(metric), duration
+      def timing(stat, msec, opts={})
+        @client.gauge prepare(stat), msec, opts
       end
     end
   end

--- a/lib/nunes/subscriber.rb
+++ b/lib/nunes/subscriber.rb
@@ -1,12 +1,14 @@
-require "active_support/notifications"
+# frozen_string_literal: true
+
+require 'active_support/notifications'
 
 module Nunes
   class Subscriber
     # Private: The bang character that is the first char of some events.
-    BANG = "!".freeze
+    BANG = '!'
 
     # Private: The dot charactor used to determine the method name.
-    DOT = ".".freeze
+    DOT = '.'
 
     # Public: Setup a subscription for the subscriber using the
     # provided adapter.
@@ -18,7 +20,7 @@ module Nunes
     end
 
     def self.pattern
-      raise "Not Implemented, override in subclass and provide a regex or string."
+      raise 'Not Implemented, override in subclass and provide a regex or string.'
     end
 
     # Private: The adapter to send instrumentation to.
@@ -50,7 +52,7 @@ module Nunes
     # opts - Arbitrary options for client (adapter).
     #
     # Returns nothing.
-    def increment(stat, opts={})
+    def increment(stat, opts = {})
       @adapter.increment stat, opts
     end
 
@@ -61,7 +63,7 @@ module Nunes
     # opts - Arbitrary options for client (adapter).
     #
     # Returns nothing.
-    def timing(stat, msec, opts={})
+    def timing(stat, msec, opts = {})
       @adapter.timing stat, msec, opts
     end
   end

--- a/lib/nunes/subscriber.rb
+++ b/lib/nunes/subscriber.rb
@@ -46,22 +46,23 @@ module Nunes
 
     # Internal: Increment a metric for the client.
     #
-    # metric - The String name of the metric to increment.
-    # value - The Integer value to increment by.
+    # stat - The String name of the metric to increment.
+    # opts - Arbitrary options for client (adapter).
     #
     # Returns nothing.
-    def increment(metric, value = 1)
-      @adapter.increment metric, value
+    def increment(stat, opts={})
+      @adapter.increment stat, opts
     end
 
     # Internal: Track the timing of a metric for the client.
     #
-    # metric - The String name of the metric.
-    # value - The Integer duration of the event in milliseconds.
+    # stat - The String name of the metric.
+    # msec - Milliseconds to record as a metric.
+    # opts - Arbitrary options for client (adapter).
     #
     # Returns nothing.
-    def timing(metric, value)
-      @adapter.timing metric, value
+    def timing(stat, msec, opts={})
+      @adapter.timing stat, msec, opts
     end
   end
 end

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -12,13 +12,9 @@ module Nunes
       end
 
       class << self
-        attr_accessor :instrument_format
         attr_accessor :instrument_view_runtime
         attr_accessor :instrument_db_runtime
       end
-
-      # Public: Should we instrument the number of requests per format overall and per controller/action.
-      self.instrument_format = true
 
       # Public: Should we instrument the view runtime overall and per controller/action.
       self.instrument_view_runtime = true
@@ -27,57 +23,25 @@ module Nunes
       self.instrument_db_runtime = true
 
       def process_action(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
-        timing "action_controller.runtime.total", runtime
+        runtime = (ending - start) * 1_000
 
-        status = payload[:status]
-        increment "action_controller.status.#{status}" if status
+        tags = {
+          status: payload[:status],
+          controller: ::Nunes.class_to_metric(payload[:controller]),
+          action: payload[:action]
+        }.compact
 
-        controller = ::Nunes.class_to_metric(payload[:controller])
-        action = payload[:action]
+        timing 'action_controller.request.duration.milliseconds', runtime, tags: tags
+        increment 'action_controller.requests.total', tags: tags if tags[:status]
 
-        if controller && action
-          timing "action_controller.controller.#{controller}.#{action}.runtime.total", runtime
-          increment "action_controller.controller.#{controller}.#{action}.status.#{status}" if status
+        if self.class.instrument_view_runtime && payload[:view_runtime]
+          view_runtime = payload[:view_runtime].round
+          timing 'action_controller.render.duration.milliseconds', view_runtime, tags: tags
         end
 
-        if self.class.instrument_view_runtime
-          view_runtime = payload[:view_runtime]
-          view_runtime = view_runtime.round if view_runtime
-
-          if view_runtime
-            timing "action_controller.runtime.view", view_runtime
-
-            if controller && action
-              timing "action_controller.controller.#{controller}.#{action}.runtime.view", view_runtime
-            end
-          end
-        end
-
-        if self.class.instrument_db_runtime
-          db_runtime = payload[:db_runtime]
-          db_runtime = db_runtime.round if db_runtime
-
-          if db_runtime
-            timing "action_controller.runtime.db", db_runtime
-
-            if controller && action
-              timing "action_controller.controller.#{controller}.#{action}.runtime.db", db_runtime
-            end
-          end
-        end
-
-        if self.class.instrument_format
-          format = payload[:format] || "all"
-          format = "all" if format == "*/*"
-
-          if format
-            increment "action_controller.format.#{format}"
-
-            if controller && action
-              increment "action_controller.controller.#{controller}.#{action}.format.#{format}"
-            end
-          end
+        if self.class.instrument_db_runtime && payload[:db_runtime]
+          db_runtime = payload[:db_runtime].round
+          timing 'action_controller.db.duration.milliseconds', db_runtime, tags: tags
         end
       end
 

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -27,7 +27,7 @@ module Nunes
       def process_action(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
 
-        tags = {
+        tags = payload[:tags] || {
           status: payload[:status],
           controller: ::Nunes.class_to_metric(payload[:controller]),
           action: payload[:action]

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -44,12 +44,12 @@ module Nunes
         increment 'action_controller.requests.total', tags: tags if tags[:status]
 
         if self.class.instrument_render_runtime && payload[:view_runtime]
-          render_runtime = payload[:view_runtime].round
+          render_runtime = payload[:view_runtime]
           timing 'action_controller.render.duration.milliseconds', render_runtime, tags: tags
         end
 
         if self.class.instrument_db_runtime && payload[:db_runtime]
-          db_runtime = payload[:db_runtime].round
+          db_runtime = payload[:db_runtime]
           timing 'action_controller.db.duration.milliseconds', db_runtime, tags: tags
         end
       end

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -1,10 +1,12 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class ActionController < ::Nunes::Subscriber
       # Private
-      Pattern = /\.action_controller\Z/
+      Pattern = /\.action_controller\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
@@ -22,7 +24,7 @@ module Nunes
       # Public: Should we instrument the db runtime overall and per controller/action.
       self.instrument_db_runtime = true
 
-      def process_action(start, ending, transaction_id, payload)
+      def process_action(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
 
         tags = {

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -27,11 +27,13 @@ module Nunes
       def process_action(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
 
-        tags = payload[:tags] || {
+        tags = payload[:tags] || {}
+
+        tags.merge!(
           status: payload[:status],
           controller: ::Nunes.class_to_metric(payload[:controller]),
           action: payload[:action]
-        }.compact
+        ).compact!
 
         if tags[:status].nil? && payload[:exception].present?
           exception_class_name = payload[:exception].first

--- a/lib/nunes/subscribers/action_mailer.rb
+++ b/lib/nunes/subscribers/action_mailer.rb
@@ -12,20 +12,20 @@ module Nunes
       end
 
       def deliver(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
+        runtime = (ending - start) * 1_000
         mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
-          timing "action_mailer.deliver.#{mailer}", runtime
+          timing 'action_mailer.deliver', runtime, tags: { mailer: mailer}
         end
       end
 
       def receive(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
+        runtime = (ending - start) * 1_000
         mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
-          timing "action_mailer.receive.#{mailer}", runtime
+          timing 'action_mailer.receive', runtime, tags: { mailer: mailer}
         end
       end
     end

--- a/lib/nunes/subscribers/action_mailer.rb
+++ b/lib/nunes/subscribers/action_mailer.rb
@@ -18,7 +18,7 @@ module Nunes
         mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
-          timing 'action_mailer.deliver', runtime, tags: { mailer: mailer }
+          timing 'action_mailer.deliver.duration.milliseconds', runtime, tags: { mailer: mailer }
         end
       end
 
@@ -27,7 +27,7 @@ module Nunes
         mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
-          timing 'action_mailer.receive', runtime, tags: { mailer: mailer }
+          timing 'action_mailer.receive.duration.milliseconds', runtime, tags: { mailer: mailer }
         end
       end
     end

--- a/lib/nunes/subscribers/action_mailer.rb
+++ b/lib/nunes/subscribers/action_mailer.rb
@@ -1,31 +1,33 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class ActionMailer < ::Nunes::Subscriber
       # Private
-      Pattern = /\.action_mailer\Z/
+      Pattern = /\.action_mailer\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
         Pattern
       end
 
-      def deliver(start, ending, transaction_id, payload)
+      def deliver(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
         mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
-          timing 'action_mailer.deliver', runtime, tags: { mailer: mailer}
+          timing 'action_mailer.deliver', runtime, tags: { mailer: mailer }
         end
       end
 
-      def receive(start, ending, transaction_id, payload)
+      def receive(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
         mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
-          timing 'action_mailer.receive', runtime, tags: { mailer: mailer}
+          timing 'action_mailer.receive', runtime, tags: { mailer: mailer }
         end
       end
     end

--- a/lib/nunes/subscribers/action_view.rb
+++ b/lib/nunes/subscribers/action_view.rb
@@ -35,7 +35,7 @@ module Nunes
           runtime = (ending - start) * 1_000
           raw_view_path = identifier.to_s.gsub(::Rails.root.to_s, Nothing)
           view_path = adapter.prepare(raw_view_path, FileSeparatorReplacement)
-          timing 'action_view.render.duration.milliseconds', runtime, tags: { kind: kind, view_path: view_path }
+          timing 'action_view.render.duration.milliseconds', runtime, tags: { kind: kind.to_s, path: view_path }
         end
       end
     end

--- a/lib/nunes/subscribers/action_view.rb
+++ b/lib/nunes/subscribers/action_view.rb
@@ -1,31 +1,33 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class ActionView < ::Nunes::Subscriber
       # Private
-      Pattern = /\.action_view\Z/
+      Pattern = /\.action_view\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
         Pattern
       end
 
-      def render_template(start, ending, transaction_id, payload)
+      def render_template(start, ending, _transaction_id, payload)
         instrument_identifier :template, payload[:identifier], start, ending
       end
 
-      def render_partial(start, ending, transaction_id, payload)
+      def render_partial(start, ending, _transaction_id, payload)
         instrument_identifier :partial, payload[:identifier], start, ending
       end
 
       private
 
       # Private: What to replace file separators with.
-      FileSeparatorReplacement = "_".freeze
+      FileSeparatorReplacement = '_'
 
       # Private: An empty string.
-      Nothing = "".freeze
+      Nothing = ''
 
       # Private: Sends timing information about identifier event.
       def instrument_identifier(kind, identifier, start, ending)
@@ -33,7 +35,7 @@ module Nunes
           runtime = (ending - start) * 1_000
           raw_view_path = identifier.to_s.gsub(::Rails.root.to_s, Nothing)
           view_path = adapter.prepare(raw_view_path, FileSeparatorReplacement)
-          timing 'action_view.render.duration.milliseconds', runtime, tags: { kind: kind , view_path: view_path }
+          timing 'action_view.render.duration.milliseconds', runtime, tags: { kind: kind, view_path: view_path }
         end
       end
     end

--- a/lib/nunes/subscribers/action_view.rb
+++ b/lib/nunes/subscribers/action_view.rb
@@ -21,28 +21,20 @@ module Nunes
 
       private
 
-      # Private: Sends timing information about identifier event.
-      def instrument_identifier(kind, identifier, start, ending)
-        if identifier
-          runtime = ((ending - start) * 1_000).round
-          timing identifier_to_metric(kind, identifier), runtime
-        end
-      end
-
       # Private: What to replace file separators with.
       FileSeparatorReplacement = "_".freeze
 
       # Private: An empty string.
       Nothing = "".freeze
 
-      # Private: Converts an identifier to a metric name. Strips out the rails
-      # root from the full path.
-      #
-      # identifier - The String full path to the template or partial.
-      def identifier_to_metric(kind, identifier)
-        view_path = identifier.to_s.gsub(::Rails.root.to_s, Nothing)
-        metric = adapter.prepare(view_path, FileSeparatorReplacement)
-        "action_view.#{kind}.#{metric}"
+      # Private: Sends timing information about identifier event.
+      def instrument_identifier(kind, identifier, start, ending)
+        if identifier
+          runtime = (ending - start) * 1_000
+          raw_view_path = identifier.to_s.gsub(::Rails.root.to_s, Nothing)
+          view_path = adapter.prepare(raw_view_path, FileSeparatorReplacement)
+          timing 'action_view.render.duration.milliseconds', runtime, tags: { kind: kind , view_path: view_path }
+        end
       end
     end
   end

--- a/lib/nunes/subscribers/active_job.rb
+++ b/lib/nunes/subscribers/active_job.rb
@@ -12,15 +12,15 @@ module Nunes
       end
 
       def perform(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
+        runtime = (ending - start) * 1_000
         job = ::Nunes.class_to_metric(payload[:job].class)
 
-        timing "active_job.#{job}.perform", runtime
+        timing 'active_job.perform.duration.milliseconds', runtime, tags: { job: job }
       end
 
       def enqueue(start, ending, transaction_id, payload)
         job = ::Nunes.class_to_metric(payload[:job].class)
-        increment "active_job.#{job}.enqueue"
+        increment 'active_job.enqueue.total', tags: { job: job }
       end
     end
   end

--- a/lib/nunes/subscribers/active_job.rb
+++ b/lib/nunes/subscribers/active_job.rb
@@ -1,24 +1,26 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class ActiveJob < ::Nunes::Subscriber
       # Private
-      Pattern = /\.active_job\Z/
+      Pattern = /\.active_job\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
         Pattern
       end
 
-      def perform(start, ending, transaction_id, payload)
+      def perform(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
         job = ::Nunes.class_to_metric(payload[:job].class)
 
         timing 'active_job.perform.duration.milliseconds', runtime, tags: { job: job }
       end
 
-      def enqueue(start, ending, transaction_id, payload)
+      def enqueue(_start, _ending, _transaction_id, payload)
         job = ::Nunes.class_to_metric(payload[:job].class)
         increment 'active_job.enqueue.total', tags: { job: job }
       end

--- a/lib/nunes/subscribers/active_job.rb
+++ b/lib/nunes/subscribers/active_job.rb
@@ -16,13 +16,16 @@ module Nunes
       def perform(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
         job = ::Nunes.class_to_metric(payload[:job].class)
+        queue = payload[:job].queue_name
 
-        timing 'active_job.perform.duration.milliseconds', runtime, tags: { job: job }
+        timing 'active_job.perform.duration.milliseconds', runtime, tags: { job: job, queue: queue }
       end
 
       def enqueue(_start, _ending, _transaction_id, payload)
         job = ::Nunes.class_to_metric(payload[:job].class)
-        increment 'active_job.enqueue.total', tags: { job: job }
+        queue = payload[:job].queue_name
+
+        increment 'active_job.enqueue.total', tags: { job: job, queue: queue }
       end
     end
   end

--- a/lib/nunes/subscribers/active_record.rb
+++ b/lib/nunes/subscribers/active_record.rb
@@ -1,10 +1,12 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class ActiveRecord < ::Nunes::Subscriber
       # Private
-      Pattern = /\.active_record\Z/
+      Pattern = /\.active_record\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
@@ -12,18 +14,18 @@ module Nunes
       end
 
       # Private: Used to detect the operation from the sql.
-      Space = " ".freeze
+      Space = ' '
 
-      def sql(start, ending, transaction_id, payload)
+      def sql(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
         name = payload[:name]
         sql = payload[:sql].to_s.strip
         operation = sql.split(Space, 2).first.to_s.downcase
 
         case operation
-        when "begin"
+        when 'begin'
           timing 'active_record.sql.transaction_begin.duration.milliseconds', runtime
-        when "commit"
+        when 'commit'
           timing 'active_record.sql.transaction_commit.duration.milliseconds', runtime
         else
           timing 'active_record.sql.duration.milliseconds', runtime, tags: { operation: operation }

--- a/lib/nunes/subscribers/active_record.rb
+++ b/lib/nunes/subscribers/active_record.rb
@@ -15,20 +15,18 @@ module Nunes
       Space = " ".freeze
 
       def sql(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
+        runtime = (ending - start) * 1_000
         name = payload[:name]
         sql = payload[:sql].to_s.strip
         operation = sql.split(Space, 2).first.to_s.downcase
 
-        timing "active_record.sql", runtime
-
         case operation
         when "begin"
-          timing "active_record.sql.transaction_begin", runtime
+          timing 'active_record.sql.transaction_begin.duration.milliseconds', runtime
         when "commit"
-          timing "active_record.sql.transaction_commit", runtime
+          timing 'active_record.sql.transaction_commit.duration.milliseconds', runtime
         else
-          timing "active_record.sql.#{operation}", runtime
+          timing 'active_record.sql.duration.milliseconds', runtime, tags: { operation: operation }
         end
       end
     end

--- a/lib/nunes/subscribers/active_record.rb
+++ b/lib/nunes/subscribers/active_record.rb
@@ -18,18 +18,10 @@ module Nunes
 
       def sql(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
-        name = payload[:name]
         sql = payload[:sql].to_s.strip
         operation = sql.split(Space, 2).first.to_s.downcase
 
-        case operation
-        when 'begin'
-          timing 'active_record.sql.transaction_begin.duration.milliseconds', runtime
-        when 'commit'
-          timing 'active_record.sql.transaction_commit.duration.milliseconds', runtime
-        else
-          timing 'active_record.sql.duration.milliseconds', runtime, tags: { operation: operation }
-        end
+        timing 'active_record.sql.duration.milliseconds', runtime, tags: { operation: operation }
       end
     end
   end

--- a/lib/nunes/subscribers/active_support.rb
+++ b/lib/nunes/subscribers/active_support.rb
@@ -1,17 +1,19 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class ActiveSupport < ::Nunes::Subscriber
       # Private
-      Pattern = /\.active_support\Z/
+      Pattern = /\.active_support\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
         Pattern
       end
 
-      def cache_read(start, ending, transaction_id, payload)
+      def cache_read(start, ending, _transaction_id, payload)
         super_operation = payload[:super_operation]
         runtime = (ending - start) * 1_000
 
@@ -29,27 +31,27 @@ module Nunes
         end
       end
 
-      def cache_generate(start, ending, transaction_id, payload)
+      def cache_generate(start, ending, _transaction_id, _payload)
         runtime = (ending - start) * 1_000
         timing 'active_support.cache.fetch_generate.duration.milliseconds', runtime
       end
 
-      def cache_fetch_hit(start, ending, transaction_id, payload)
+      def cache_fetch_hit(start, ending, _transaction_id, _payload)
         runtime = (ending - start) * 1_000
         timing 'active_support.cache.fetch_hit.duration.milliseconds', runtime
       end
 
-      def cache_write(start, ending, transaction_id, payload)
+      def cache_write(start, ending, _transaction_id, _payload)
         runtime = (ending - start) * 1_000
         timing 'active_support.cache.write.duration.milliseconds', runtime
       end
 
-      def cache_delete(start, ending, transaction_id, payload)
+      def cache_delete(start, ending, _transaction_id, _payload)
         runtime = (ending - start) * 1_000
         timing 'active_support.cache.delete.duration.milliseconds', runtime
       end
 
-      def cache_exist?(start, ending, transaction_id, payload)
+      def cache_exist?(start, ending, _transaction_id, _payload)
         runtime = (ending - start) * 1_000
         timing 'active_support.cache.exist.duration.milliseconds', runtime
       end

--- a/lib/nunes/subscribers/active_support.rb
+++ b/lib/nunes/subscribers/active_support.rb
@@ -13,45 +13,45 @@ module Nunes
 
       def cache_read(start, ending, transaction_id, payload)
         super_operation = payload[:super_operation]
-        runtime = ((ending - start) * 1_000).round
+        runtime = (ending - start) * 1_000
 
         case super_operation
         when Symbol
-          timing "active_support.cache.#{super_operation}", runtime
+          timing "active_support.cache.#{super_operation}.duration.milliseconds", runtime
         else
-          timing "active_support.cache.read", runtime
+          timing 'active_support.cache.read.duration.milliseconds', runtime
         end
 
         hit = payload[:hit]
         unless hit.nil?
           hit_type = hit ? :hit : :miss
-          increment "active_support.cache.#{hit_type}"
+          increment "active_support.cache.#{hit_type}.total"
         end
       end
 
       def cache_generate(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
-        timing "active_support.cache.fetch_generate", runtime
+        runtime = (ending - start) * 1_000
+        timing 'active_support.cache.fetch_generate.duration.milliseconds', runtime
       end
 
       def cache_fetch_hit(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
-        timing "active_support.cache.fetch_hit", runtime
+        runtime = (ending - start) * 1_000
+        timing 'active_support.cache.fetch_hit.duration.milliseconds', runtime
       end
 
       def cache_write(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
-        timing "active_support.cache.write", runtime
+        runtime = (ending - start) * 1_000
+        timing 'active_support.cache.write.duration.milliseconds', runtime
       end
 
       def cache_delete(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
-        timing "active_support.cache.delete", runtime
+        runtime = (ending - start) * 1_000
+        timing 'active_support.cache.delete.duration.milliseconds', runtime
       end
 
       def cache_exist?(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
-        timing "active_support.cache.exist", runtime
+        runtime = (ending - start) * 1_000
+        timing 'active_support.cache.exist.duration.milliseconds', runtime
       end
     end
   end

--- a/lib/nunes/subscribers/nunes.rb
+++ b/lib/nunes/subscribers/nunes.rb
@@ -1,17 +1,19 @@
-require "nunes/subscriber"
+# frozen_string_literal: true
+
+require 'nunes/subscriber'
 
 module Nunes
   module Subscribers
     class Nunes < ::Nunes::Subscriber
       # Private
-      Pattern = /\.nunes\Z/
+      Pattern = /\.nunes\Z/.freeze
 
       # Private: The namespace for events to subscribe to.
       def self.pattern
         Pattern
       end
 
-      def instrument_method_time(start, ending, transaction_id, payload)
+      def instrument_method_time(start, ending, _transaction_id, payload)
         runtime = (ending - start) * 1_000
         metric = payload[:metric]
 

--- a/lib/nunes/subscribers/nunes.rb
+++ b/lib/nunes/subscribers/nunes.rb
@@ -12,10 +12,10 @@ module Nunes
       end
 
       def instrument_method_time(start, ending, transaction_id, payload)
-        runtime = ((ending - start) * 1_000).round
+        runtime = (ending - start) * 1_000
         metric = payload[:metric]
 
-        timing "#{metric}", runtime if metric
+        timing metric, runtime if metric
       end
     end
   end

--- a/lib/nunes/version.rb
+++ b/lib/nunes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nunes
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/lib/nunes/version.rb
+++ b/lib/nunes/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nunes
-  VERSION = "0.5.0"
+  VERSION = '0.5.0'
 end

--- a/lib/nunes/version.rb
+++ b/lib/nunes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nunes
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/lib/nunes/version.rb
+++ b/lib/nunes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nunes
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/nunes.gemspec
+++ b/nunes.gemspec
@@ -1,22 +1,23 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'nunes/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "nunes"
+  spec.name          = 'nunes'
   spec.version       = Nunes::VERSION
-  spec.authors       = ["John Nunemaker"]
-  spec.email         = ["nunemaker@gmail.com"]
-  spec.description   = %q{The friendly gem that instruments everything for you, like I would if I could.}
-  spec.summary       = %q{The friendly gem that instruments everything for you, like I would if I could.}
-  spec.homepage      = "https://github.com/jnunemaker/nunes"
-  spec.license       = "MIT"
+  spec.authors       = ['John Nunemaker']
+  spec.email         = ['nunemaker@gmail.com']
+  spec.description   = 'The friendly gem that instruments everything for you, like I would if I could.'
+  spec.summary       = 'The friendly gem that instruments everything for you, like I would if I could.'
+  spec.homepage      = 'https://github.com/jnunemaker/nunes'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
 end

--- a/script/bench.rb
+++ b/script/bench.rb
@@ -1,19 +1,21 @@
-require "benchmark"
-require "securerandom"
-require "active_support/notifications"
-require "bundler"
+# frozen_string_literal: true
+
+require 'benchmark'
+require 'securerandom'
+require 'active_support/notifications'
+require 'bundler'
 Bundler.setup :default, :bench
 
-require_relative "../lib/nunes"
+require_relative '../lib/nunes'
 
 adapter = Nunes::Adapter.wrap({})
 Nunes::Subscribers::ActionController.subscribe(adapter)
 
-require "rblineprof"
+require 'rblineprof'
 $profile = lineprof(/./) do
   puts Benchmark.realtime {
     1_000.times do
-      ActiveSupport::Notifications.instrument("process_action.action_controller")
+      ActiveSupport::Notifications.instrument('process_action.action_controller')
     end
   }
 end
@@ -21,12 +23,12 @@ end
 def show_file(file)
   file = File.expand_path(file)
   File.readlines(file).each_with_index do |line, num|
-    wall, cpu, calls = $profile[file][num+1]
+    wall, cpu, calls = $profile[file][num + 1]
     if calls && calls > 0
-      printf "% 8.1fms + % 8.1fms (% 5d) | %s", cpu/1000.0, (wall-cpu)/1000.0, calls, line
+      printf '% 8.1fms + % 8.1fms (% 5d) | %s', cpu / 1000.0, (wall - cpu) / 1000.0, calls, line
       # printf "% 8.1fms (% 5d) | %s", wall/1000.0, calls, line
     else
-      printf "                                | %s", line
+      printf '                                | %s', line
       # printf "                   | %s", line
     end
   end
@@ -36,13 +38,11 @@ puts
 $profile.each do |file, data|
   total, child, exclusive = data[0]
   puts file
-  printf "  % 10.1fms in this file\n", exclusive/1000.0
-  printf "  % 10.1fms in this file + children\n", total/1000.0
-  printf "  % 10.1fms in children\n", child/1000.0
+  printf "  % 10.1fms in this file\n", exclusive / 1000.0
+  printf "  % 10.1fms in this file + children\n", total / 1000.0
+  printf "  % 10.1fms in children\n", child / 1000.0
 
-  if file =~ /nunes\/lib/
-    show_file(file)
-  end
+  show_file(file) if file =~ %r{nunes/lib}
 
   puts
 end

--- a/script/watch
+++ b/script/watch
@@ -1,30 +1,32 @@
 #!/usr/bin/env ruby
-#/ Usage: watch
-#/
-#/ Run the tests whenever any relevant files change.
-#/
+# frozen_string_literal: true
 
-require "pathname"
-require "rubygems"
-require "bundler"
+# / Usage: watch
+# /
+# / Run the tests whenever any relevant files change.
+# /
+
+require 'pathname'
+require 'rubygems'
+require 'bundler'
 Bundler.setup :watch
 
 # Put us where we belong, in the root dir of the project.
-Dir.chdir Pathname.new(__FILE__).realpath + "../.."
+Dir.chdir Pathname.new(__FILE__).realpath + '../..'
 
 # Run the tests to start.
-system "clear; script/test"
+system 'clear; script/test'
 
-require "rb-fsevent"
+require 'rb-fsevent'
 
-IgnoreRegex = /\/log|db/
+IgnoreRegex = %r{/log|db}.freeze
 
 fs = FSEvent.new
-fs.watch ["lib", "test"], latency: 1 do |args|
+fs.watch ['lib', 'test'], latency: 1 do |args|
   unless args.first =~ IgnoreRegex
-    system "clear"
+    system 'clear'
     puts "#{args.first} changed..."
-    system "script/test"
+    system 'script/test'
   end
 end
 fs.run

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -54,22 +54,20 @@ class AdapterTest < ActiveSupport::TestCase
 
   test 'passes increment along' do
     mock = MiniTest::Mock.new
-    mock.expect :increment, nil, ['single', 1]
-    mock.expect :increment, nil, ['double', 2]
+    mock.expect :increment, nil, ['single', tags: { foo: 'bar' }]
 
     client = Nunes::Adapter.new(mock)
-    client.increment('single')
-    client.increment('double', 2)
+    client.increment('single', tags: { foo: 'bar' })
 
     mock.verify
   end
 
   test 'passes timing along' do
     mock = MiniTest::Mock.new
-    mock.expect :timing, nil, ['foo', 23]
+    mock.expect :timing, nil, ['foo', 23, { tags: { foo: 'bar' } }]
 
     client = Nunes::Adapter.new(mock)
-    client.timing('foo', 23)
+    client.timing('foo', 23, tags: { foo: 'bar' })
 
     mock.verify
   end
@@ -114,7 +112,7 @@ class AdapterTest < ActiveSupport::TestCase
   test 'prepare does not modify original metric object' do
     adapter = Nunes::Adapter.new(nil)
     original = 'app.views.posts'
-    result = adapter.prepare('original')
+    _ = adapter.prepare('original')
 
     assert_equal 'app.views.posts', original
   end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -1,15 +1,19 @@
-require "helper"
-require "minitest/mock"
+# frozen_string_literal: true
+
+require 'helper'
+require 'minitest/mock'
 
 class AdapterTest < ActiveSupport::TestCase
   def separator
     Nunes::Adapter::Separator
   end
 
-  test "wrap for statsd" do
+  test 'wrap for statsd' do
     client_with_gauge_and_timing = Class.new do
       def increment(*args); end
+
       def gauge(*args); end
+
       def timing(*args); end
     end.new
 
@@ -17,9 +21,10 @@ class AdapterTest < ActiveSupport::TestCase
     assert_instance_of Nunes::Adapter, adapter
   end
 
-  test "wrap for instrumental" do
+  test 'wrap for instrumental' do
     client_with_gauge_but_not_timing = Class.new do
       def increment(*args); end
+
       def gauge(*args); end
     end.new
 
@@ -27,90 +32,90 @@ class AdapterTest < ActiveSupport::TestCase
     assert_instance_of Nunes::Adapters::TimingAliased, adapter
   end
 
-  test "wrap for adapter" do
+  test 'wrap for adapter' do
     memory = Nunes::Adapters::Memory.new
     adapter = Nunes::Adapter.wrap(memory)
     assert_equal memory, adapter
   end
 
-  test "wrap with hash" do
+  test 'wrap with hash' do
     hash = {}
     adapter = Nunes::Adapter.wrap(hash)
     assert_instance_of Nunes::Adapters::Memory, adapter
   end
 
-  test "wrap with nil" do
+  test 'wrap with nil' do
     assert_raises(ArgumentError) { Nunes::Adapter.wrap(nil) }
   end
 
-  test "wrap with straight up gibberish yo" do
+  test 'wrap with straight up gibberish yo' do
     assert_raises(ArgumentError) { Nunes::Adapter.wrap(Object.new) }
   end
 
-  test "passes increment along" do
+  test 'passes increment along' do
     mock = MiniTest::Mock.new
-    mock.expect :increment, nil, ["single", 1]
-    mock.expect :increment, nil, ["double", 2]
+    mock.expect :increment, nil, ['single', 1]
+    mock.expect :increment, nil, ['double', 2]
 
     client = Nunes::Adapter.new(mock)
-    client.increment("single")
-    client.increment("double", 2)
+    client.increment('single')
+    client.increment('double', 2)
 
     mock.verify
   end
 
-  test "passes timing along" do
+  test 'passes timing along' do
     mock = MiniTest::Mock.new
-    mock.expect :timing, nil, ["foo", 23]
+    mock.expect :timing, nil, ['foo', 23]
 
     client = Nunes::Adapter.new(mock)
-    client.timing("foo", 23)
+    client.timing('foo', 23)
 
     mock.verify
   end
 
-  test "prepare leaves good metrics alone" do
+  test 'prepare leaves good metrics alone' do
     adapter = Nunes::Adapter.new(nil)
 
     [
-      "foo",
-      "foo1234",
-      "foo-bar",
-      "foo_bar",
-      "Foo",
-      "FooBar",
-      "FOOBAR",
+      'foo',
+      'foo1234',
+      'foo-bar',
+      'foo_bar',
+      'Foo',
+      'FooBar',
+      'FOOBAR',
       "foo#{separator}bar",
       "foo#{separator}bar_baz",
       "foo#{separator}bar_baz-wick",
       "Foo#{separator}1234",
-      "Foo#{separator}Bar1234",
+      "Foo#{separator}Bar1234"
     ].each do |expected|
       assert_equal expected, adapter.prepare(expected)
     end
   end
 
-  test "prepare with bad metric names" do
+  test 'prepare with bad metric names' do
     adapter = Nunes::Adapter.new(nil)
 
     {
-      "#{separator}foo"                         => "foo",
-      "foo#{separator}"                         => "foo",
-      "foo@bar"                                 => "foo#{separator}bar",
-      "foo@$%^*^&bar"                           => "foo#{separator}bar",
-      "foo#{separator}#{separator}bar"          => "foo#{separator}bar",
-      "app/views/posts"                         => "app#{separator}views#{separator}posts",
-      "Admin::PostsController#{separator}index" => "Admin#{separator}PostsController#{separator}index",
+      "#{separator}foo" => 'foo',
+      "foo#{separator}" => 'foo',
+      'foo@bar' => "foo#{separator}bar",
+      'foo@$%^*^&bar' => "foo#{separator}bar",
+      "foo#{separator}#{separator}bar" => "foo#{separator}bar",
+      'app/views/posts' => "app#{separator}views#{separator}posts",
+      "Admin::PostsController#{separator}index" => "Admin#{separator}PostsController#{separator}index"
     }.each do |metric, expected|
       assert_equal expected, adapter.prepare(metric)
     end
   end
 
-  test "prepare does not modify original metric object" do
+  test 'prepare does not modify original metric object' do
     adapter = Nunes::Adapter.new(nil)
-    original = "app.views.posts"
-    result = adapter.prepare("original")
+    original = 'app.views.posts'
+    result = adapter.prepare('original')
 
-    assert_equal "app.views.posts", original
+    assert_equal 'app.views.posts', original
   end
 end

--- a/test/adapters/timing_aliased_test.rb
+++ b/test/adapters/timing_aliased_test.rb
@@ -1,25 +1,27 @@
-require "helper"
-require "minitest/mock"
+# frozen_string_literal: true
+
+require 'helper'
+require 'minitest/mock'
 
 class TimingAliasedAdapterTest < ActiveSupport::TestCase
-  test "passes increment along" do
+  test 'passes increment along' do
     mock = MiniTest::Mock.new
-    mock.expect :increment, nil, ["single", 1]
-    mock.expect :increment, nil, ["double", 2]
+    mock.expect :increment, nil, ['single', 1]
+    mock.expect :increment, nil, ['double', 2]
 
     client = Nunes::Adapters::TimingAliased.new(mock)
-    client.increment("single")
-    client.increment("double", 2)
+    client.increment('single')
+    client.increment('double', 2)
 
     mock.verify
   end
 
-  test "sends timing to gauge" do
+  test 'sends timing to gauge' do
     mock = MiniTest::Mock.new
-    mock.expect :gauge, nil, ["foo", 23]
+    mock.expect :gauge, nil, ['foo', 23]
 
     client = Nunes::Adapters::TimingAliased.new(mock)
-    client.timing("foo", 23)
+    client.timing('foo', 23)
 
     mock.verify
   end

--- a/test/adapters/timing_aliased_test.rb
+++ b/test/adapters/timing_aliased_test.rb
@@ -6,22 +6,20 @@ require 'minitest/mock'
 class TimingAliasedAdapterTest < ActiveSupport::TestCase
   test 'passes increment along' do
     mock = MiniTest::Mock.new
-    mock.expect :increment, nil, ['single', 1]
-    mock.expect :increment, nil, ['double', 2]
+    mock.expect :increment, nil, ['single', tags: { food: 'bar' }]
 
     client = Nunes::Adapters::TimingAliased.new(mock)
-    client.increment('single')
-    client.increment('double', 2)
+    client.increment('single', tags: { food: 'bar' })
 
     mock.verify
   end
 
   test 'sends timing to gauge' do
     mock = MiniTest::Mock.new
-    mock.expect :gauge, nil, ['foo', 23]
+    mock.expect :gauge, nil, ['foo', 23, tags: { foo: 'bar' }]
 
     client = Nunes::Adapters::TimingAliased.new(mock)
-    client.timing('foo', 23)
+    client.timing('foo', 23, tags: { foo: 'bar' })
 
     mock.verify
   end

--- a/test/cache_instrumentation_test.rb
+++ b/test/cache_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class CacheInstrumentationTest < ActiveSupport::TestCase
   attr_reader :cache
@@ -26,56 +28,56 @@ class CacheInstrumentationTest < ActiveSupport::TestCase
     @cache = nil
   end
 
-  test "cache_read miss" do
+  test 'cache_read miss' do
     cache.read('foo')
 
-    assert_timer "active_support.cache.read"
-    assert_counter "active_support.cache.miss"
+    assert_timer 'active_support.cache.read'
+    assert_counter 'active_support.cache.miss'
   end
 
-  test "cache_read hit" do
+  test 'cache_read hit' do
     cache.write('foo', 'bar')
     adapter.clear
     cache.read('foo')
 
-    assert_timer "active_support.cache.read"
-    assert_counter "active_support.cache.hit"
+    assert_timer 'active_support.cache.read'
+    assert_counter 'active_support.cache.hit'
   end
 
-  test "cache_generate" do
-    cache.fetch('foo') { |key| :generate_me_please }
-    assert_timer "active_support.cache.fetch_generate"
+  test 'cache_generate' do
+    cache.fetch('foo') { |_key| :generate_me_please }
+    assert_timer 'active_support.cache.fetch_generate'
   end
 
-  test "cache_fetch with hit" do
+  test 'cache_fetch with hit' do
     cache.write('foo', 'bar')
     adapter.clear
-    cache.fetch('foo') { |key| :never_gets_here }
+    cache.fetch('foo') { |_key| :never_gets_here }
 
-    assert_timer "active_support.cache.fetch"
-    assert_timer "active_support.cache.fetch_hit"
+    assert_timer 'active_support.cache.fetch'
+    assert_timer 'active_support.cache.fetch_hit'
   end
 
-  test "cache_fetch with miss" do
+  test 'cache_fetch with miss' do
     cache.fetch('foo') { 'foo value set here' }
 
-    assert_timer "active_support.cache.fetch"
-    assert_timer "active_support.cache.fetch_generate"
-    assert_timer "active_support.cache.write"
+    assert_timer 'active_support.cache.fetch'
+    assert_timer 'active_support.cache.fetch_generate'
+    assert_timer 'active_support.cache.write'
   end
 
-  test "cache_write" do
+  test 'cache_write' do
     cache.write('foo', 'bar')
-    assert_timer "active_support.cache.write"
+    assert_timer 'active_support.cache.write'
   end
 
-  test "cache_delete" do
+  test 'cache_delete' do
     cache.delete('foo')
-    assert_timer "active_support.cache.delete"
+    assert_timer 'active_support.cache.delete'
   end
 
-  test "cache_exist?" do
+  test 'cache_exist?' do
     cache.exist?('foo')
-    assert_timer "active_support.cache.exist"
+    assert_timer 'active_support.cache.exist'
   end
 end

--- a/test/cache_instrumentation_test.rb
+++ b/test/cache_instrumentation_test.rb
@@ -31,8 +31,8 @@ class CacheInstrumentationTest < ActiveSupport::TestCase
   test 'cache_read miss' do
     cache.read('foo')
 
-    assert_timer 'active_support.cache.read'
-    assert_counter 'active_support.cache.miss'
+    assert_timer 'active_support.cache.read.duration.milliseconds'
+    assert_counter 'active_support.cache.miss.total'
   end
 
   test 'cache_read hit' do
@@ -40,13 +40,13 @@ class CacheInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     cache.read('foo')
 
-    assert_timer 'active_support.cache.read'
-    assert_counter 'active_support.cache.hit'
+    assert_timer 'active_support.cache.read.duration.milliseconds'
+    assert_counter 'active_support.cache.hit.total'
   end
 
   test 'cache_generate' do
     cache.fetch('foo') { |_key| :generate_me_please }
-    assert_timer 'active_support.cache.fetch_generate'
+    assert_timer 'active_support.cache.fetch_generate.duration.milliseconds'
   end
 
   test 'cache_fetch with hit' do
@@ -54,30 +54,30 @@ class CacheInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     cache.fetch('foo') { |_key| :never_gets_here }
 
-    assert_timer 'active_support.cache.fetch'
-    assert_timer 'active_support.cache.fetch_hit'
+    assert_timer 'active_support.cache.fetch.duration.milliseconds'
+    assert_timer 'active_support.cache.fetch_hit.duration.milliseconds'
   end
 
   test 'cache_fetch with miss' do
     cache.fetch('foo') { 'foo value set here' }
 
-    assert_timer 'active_support.cache.fetch'
-    assert_timer 'active_support.cache.fetch_generate'
-    assert_timer 'active_support.cache.write'
+    assert_timer 'active_support.cache.fetch.duration.milliseconds'
+    assert_timer 'active_support.cache.fetch_generate.duration.milliseconds'
+    assert_timer 'active_support.cache.write.duration.milliseconds'
   end
 
   test 'cache_write' do
     cache.write('foo', 'bar')
-    assert_timer 'active_support.cache.write'
+    assert_timer 'active_support.cache.write.duration.milliseconds'
   end
 
   test 'cache_delete' do
     cache.delete('foo')
-    assert_timer 'active_support.cache.delete'
+    assert_timer 'active_support.cache.delete.duration.milliseconds'
   end
 
   test 'cache_exist?' do
     cache.exist?('foo')
-    assert_timer 'active_support.cache.exist'
+    assert_timer 'active_support.cache.exist.duration.milliseconds'
   end
 end

--- a/test/controller_instrumentation_test.rb
+++ b/test/controller_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class ControllerInstrumentationTest < ActionController::TestCase
   tests PostsController
@@ -14,99 +16,103 @@ class ControllerInstrumentationTest < ActionController::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "process_action" do
+  test 'process_action' do
     get :index
 
     assert_response :success
 
-    assert_counter "action_controller.status.200"
+    assert_counter 'action_controller.status.200'
 
-    assert_timer "action_controller.runtime.total"
-    assert_timer "action_controller.runtime.db"
-    assert_timer "action_controller.runtime.view"
+    assert_timer 'action_controller.runtime.total'
+    assert_timer 'action_controller.runtime.db'
+    assert_timer 'action_controller.runtime.view'
 
-    assert_timer "action_controller.controller.PostsController.index.runtime.total"
-    assert_timer "action_controller.controller.PostsController.index.runtime.view"
-    assert_timer "action_controller.controller.PostsController.index.runtime.db"
+    assert_timer 'action_controller.controller.PostsController.index.runtime.total'
+    assert_timer 'action_controller.controller.PostsController.index.runtime.view'
+    assert_timer 'action_controller.controller.PostsController.index.runtime.db'
   end
 
-  test "send_data" do
+  test 'send_data' do
     get :some_data
 
     assert_response :success
 
-    assert_counter "action_controller.requests.total", tags: {status: 200}
+    assert_counter 'action_controller.requests.total', tags: { status: 200 }
 
-    assert_timer "action_controller.runtime.total"
-    assert_timer "action_controller.runtime.view"
+    assert_timer 'action_controller.runtime.total'
+    assert_timer 'action_controller.runtime.view'
 
-    assert_timer "action_controller.controller.PostsController.some_data.runtime.total"
-    assert_timer "action_controller.controller.PostsController.some_data.runtime.view"
+    assert_timer 'action_controller.controller.PostsController.some_data.runtime.total'
+    assert_timer 'action_controller.controller.PostsController.some_data.runtime.view'
   end
 
-  test "send_file" do
+  test 'send_file' do
     get :some_file
 
     assert_response :success
 
-    assert_counter"action_controller.status.200"
+    assert_counter 'action_controller.status.200'
 
-    assert_timer "action_controller.runtime.total"
-    assert_timer "action_controller.controller.PostsController.some_file.runtime.total"
+    assert_timer 'action_controller.runtime.total'
+    assert_timer 'action_controller.controller.PostsController.some_file.runtime.total'
 
-    assert ! adapter.timer?("action_controller.runtime.view")
-    assert ! adapter.timer?("action_controller.controller.PostsController.some_file.runtime.view")
+    assert !adapter.timer?('action_controller.runtime.view')
+    assert !adapter.timer?('action_controller.controller.PostsController.some_file.runtime.view')
   end
 
-  test "redirect_to" do
+  test 'redirect_to' do
     get :some_redirect
 
     assert_response :redirect
 
-    assert_counter "action_controller.requests.total", tags: {status: 302, controller: 'PostsController', action: 'some_redirect'}
+    assert_counter 'action_controller.requests.total', tags: { status: 302, controller: 'PostsController', action: 'some_redirect' }
 
-    assert_timer "action_controller.runtime.total"
-    assert_timer "action_controller.controller.PostsController.some_redirect.runtime.total"
+    assert_timer 'action_controller.runtime.total'
+    assert_timer 'action_controller.controller.PostsController.some_redirect.runtime.total'
 
-    refute_timer "action_controller.runtime.view"
-    refute_timer "action_controller.controller.PostsController.some_redirect.runtime.view"
+    refute_timer 'action_controller.runtime.view'
+    refute_timer 'action_controller.controller.PostsController.some_redirect.runtime.view'
   end
 
-  test "action with exception" do
-    get :some_boom rescue StandardError # catch the boom
+  test 'action with exception' do
+    begin
+      get :some_boom
+    rescue StandardError
+      StandardError
+    end # catch the boom
 
     assert_response :success
 
-    assert_timer "action_controller.runtime.total"
-    assert_timer "action_controller.controller.PostsController.some_boom.runtime.total"
+    assert_timer 'action_controller.runtime.total'
+    assert_timer 'action_controller.controller.PostsController.some_boom.runtime.total'
 
-    refute_timer "action_controller.runtime.view"
-    refute_timer "action_controller.controller.PostsController.some_boom.runtime.view"
+    refute_timer 'action_controller.runtime.view'
+    refute_timer 'action_controller.controller.PostsController.some_boom.runtime.view'
   end
 
-  test "with instrument db runtime disabled" do
+  test 'with instrument db runtime disabled' do
     begin
       original_db_enabled = Nunes::Subscribers::ActionController.instrument_db_runtime
       Nunes::Subscribers::ActionController.instrument_db_runtime = false
 
       get :index
 
-      refute_timer "action_controller.runtime.db"
-      refute_timer "action_controller.controller.PostsController.index.runtime.db"
+      refute_timer 'action_controller.runtime.db'
+      refute_timer 'action_controller.controller.PostsController.index.runtime.db'
     ensure
       Nunes::Subscribers::ActionController.instrument_db_runtime = original_db_enabled
     end
   end
 
-  test "with instrument view runtime disabled" do
+  test 'with instrument view runtime disabled' do
     begin
       original_view_enabled = Nunes::Subscribers::ActionController.instrument_view_runtime
       Nunes::Subscribers::ActionController.instrument_view_runtime = false
 
       get :index
 
-      refute_timer "action_controller.runtime.view"
-      refute_timer "action_controller.controller.PostsController.index.runtime.view"
+      refute_timer 'action_controller.runtime.view'
+      refute_timer 'action_controller.controller.PostsController.index.runtime.view'
     ensure
       Nunes::Subscribers::ActionController.instrument_view_runtime = original_view_enabled
     end

--- a/test/controller_instrumentation_test.rb
+++ b/test/controller_instrumentation_test.rb
@@ -20,7 +20,6 @@ class ControllerInstrumentationTest < ActionController::TestCase
     assert_response :success
 
     assert_counter "action_controller.status.200"
-    assert_counter "action_controller.format.html"
 
     assert_timer "action_controller.runtime.total"
     assert_timer "action_controller.runtime.db"
@@ -36,7 +35,7 @@ class ControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :success
 
-    assert_counter "action_controller.status.200"
+    assert_counter "action_controller.requests.total", tags: {status: 200}
 
     assert_timer "action_controller.runtime.total"
     assert_timer "action_controller.runtime.view"
@@ -64,7 +63,7 @@ class ControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :redirect
 
-    assert_counter "action_controller.status.302"
+    assert_counter "action_controller.requests.total", tags: {status: 302, controller: 'PostsController', action: 'some_redirect'}
 
     assert_timer "action_controller.runtime.total"
     assert_timer "action_controller.controller.PostsController.some_redirect.runtime.total"
@@ -78,8 +77,6 @@ class ControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :success
 
-    assert_counter "action_controller.format.html"
-
     assert_timer "action_controller.runtime.total"
     assert_timer "action_controller.controller.PostsController.some_boom.runtime.total"
 
@@ -87,22 +84,9 @@ class ControllerInstrumentationTest < ActionController::TestCase
     refute_timer "action_controller.controller.PostsController.some_boom.runtime.view"
   end
 
-  test "with instrument format disabled" do
-    begin
-      original_format_enabled = Nunes::Subscribers::ActionController.instrument_format
-      Nunes::Subscribers::ActionController.instrument_format = false
-
-      get :index
-
-      refute_counter "action_controller.format.html"
-    ensure
-      Nunes::Subscribers::ActionController.instrument_format = original_format_enabled
-    end
-  end
-
   test "with instrument db runtime disabled" do
     begin
-      original_format_enabled = Nunes::Subscribers::ActionController.instrument_db_runtime
+      original_db_enabled = Nunes::Subscribers::ActionController.instrument_db_runtime
       Nunes::Subscribers::ActionController.instrument_db_runtime = false
 
       get :index
@@ -110,13 +94,13 @@ class ControllerInstrumentationTest < ActionController::TestCase
       refute_timer "action_controller.runtime.db"
       refute_timer "action_controller.controller.PostsController.index.runtime.db"
     ensure
-      Nunes::Subscribers::ActionController.instrument_db_runtime = original_format_enabled
+      Nunes::Subscribers::ActionController.instrument_db_runtime = original_db_enabled
     end
   end
 
   test "with instrument view runtime disabled" do
     begin
-      original_format_enabled = Nunes::Subscribers::ActionController.instrument_view_runtime
+      original_view_enabled = Nunes::Subscribers::ActionController.instrument_view_runtime
       Nunes::Subscribers::ActionController.instrument_view_runtime = false
 
       get :index
@@ -124,7 +108,7 @@ class ControllerInstrumentationTest < ActionController::TestCase
       refute_timer "action_controller.runtime.view"
       refute_timer "action_controller.controller.PostsController.index.runtime.view"
     ensure
-      Nunes::Subscribers::ActionController.instrument_view_runtime = original_format_enabled
+      Nunes::Subscribers::ActionController.instrument_view_runtime = original_view_enabled
     end
   end
 end

--- a/test/controller_instrumentation_test.rb
+++ b/test/controller_instrumentation_test.rb
@@ -24,7 +24,8 @@ class ControllerInstrumentationTest < ActionController::TestCase
     expected_tags = {
       status: 200,
       controller: 'posts_controller',
-      action: 'index'
+      action: 'index',
+      foo: 'bar'
     }
 
     assert_counter 'action_controller.requests.total', tags: expected_tags

--- a/test/fake_udp_socket_test.rb
+++ b/test/fake_udp_socket_test.rb
@@ -1,25 +1,27 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class FakeUdpSocketTest < ActiveSupport::TestCase
-  test "timer boolean" do
+  test 'timer boolean' do
     socket = FakeUdpSocket.new
-    socket.send "action_controller.posts.index.runtime:2|ms"
-    assert_equal true,  socket.timer?("action_controller.posts.index.runtime")
-    assert_equal false, socket.timer?("action_controller.posts.index.faketime")
+    socket.send 'action_controller.posts.index.runtime:2|ms'
+    assert_equal true,  socket.timer?('action_controller.posts.index.runtime')
+    assert_equal false, socket.timer?('action_controller.posts.index.faketime')
   end
 
-  test "counter boolean" do
+  test 'counter boolean' do
     socket = FakeUdpSocket.new
-    socket.send "action_controller.status.200:1|c"
-    assert_equal true,  socket.counter?("action_controller.status.200")
-    assert_equal false, socket.counter?("action_controller.status.400")
+    socket.send 'action_controller.status.200:1|c'
+    assert_equal true,  socket.counter?('action_controller.status.200')
+    assert_equal false, socket.counter?('action_controller.status.400')
   end
 
-  test "send, recv and clear" do
+  test 'send, recv and clear' do
     socket = FakeUdpSocket.new
-    socket.send "foo"
-    socket.send "bar"
-    assert_equal "foo", socket.recv
+    socket.send 'foo'
+    socket.send 'bar'
+    assert_equal 'foo', socket.recv
     socket.clear
     assert_nil socket.recv
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,14 @@
-ENV["RAILS_ENV"] = "test"
+# frozen_string_literal: true
 
-require "rails"
-require "rails/test_help"
-require "action_mailer"
+ENV['RAILS_ENV'] = 'test'
+
+require 'rails'
+require 'rails/test_help'
+require 'action_mailer'
 
 # require everything in the support directory
-root = Pathname(__FILE__).dirname.join("..").expand_path
-Dir[root.join("test/support/**/*.rb")].each { |f| require f }
+root = Pathname(__FILE__).dirname.join('..').expand_path
+Dir[root.join('test/support/**/*.rb')].each { |f| require f }
 
 puts "Running tests against rails version #{Rails.version}"
 
@@ -22,8 +24,8 @@ class ActiveSupport::TestCase
   include AdapterTestHelpers
 end
 
-rails_version = ENV["RAILS_VERSION"] || "4.2.5"
+rails_version = ENV['RAILS_VERSION'] || '4.2.5'
 
 require "rails_app_#{rails_version}/config/environment"
 
-require "nunes"
+require 'nunes'

--- a/test/instrumentable_test.rb
+++ b/test/instrumentable_test.rb
@@ -75,7 +75,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     assert_equal 'thing.yo', event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
-    assert_timer 'Thing.yo'
+    assert_timer 'thing.yo'
   end
 
   test 'instrument_method_time for class method without full metric name' do
@@ -138,10 +138,10 @@ class InstrumentationTest < ActiveSupport::TestCase
     event = slurp_events { namespaced_thing_class.new.yo(some: 'thing') }.last
 
     assert_not_nil event, 'No events were found.'
-    assert_equal 'some-Thing.yo', event.payload[:metric]
+    assert_equal 'some_thing.yo', event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
-    assert_timer 'Some-Thing.yo'
+    assert_timer 'some_thing.yo'
   end
 
   def slurp_events(&block)

--- a/test/instrumentable_test.rb
+++ b/test/instrumentable_test.rb
@@ -70,7 +70,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     event = slurp_events { thing_class.new.yo(some: 'thing') }.last
 
     assert_not_nil event, "No events were found."
-    assert_equal "Thing.yo", event.payload[:metric]
+    assert_equal "thing.yo", event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
     assert_timer "Thing.yo"
@@ -127,7 +127,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     assert_not_nil event, "No events were found."
     assert_equal "loadin", event.payload[:pay]
 
-    assert_timer "Thing.yo"
+    assert_timer "thing.yo"
   end
 
   test "instrument_method_time for namespaced class" do
@@ -136,7 +136,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     event = slurp_events { namespaced_thing_class.new.yo(some: 'thing') }.last
 
     assert_not_nil event, "No events were found."
-    assert_equal "Some-Thing.yo", event.payload[:metric]
+    assert_equal "some-Thing.yo", event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
     assert_timer "Some-Thing.yo"

--- a/test/instrumentable_test.rb
+++ b/test/instrumentable_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class InstrumentationTest < ActiveSupport::TestCase
   attr_reader :thing_class, :namespaced_thing_class
@@ -15,13 +17,13 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   def setup_class
-    @thing_class = Class.new {
+    @thing_class = Class.new do
       extend Nunes::Instrumentable
 
       class << self
         extend Nunes::Instrumentable
 
-        def find(*args)
+        def find(*_args)
           :nope
         end
       end
@@ -30,21 +32,21 @@ class InstrumentationTest < ActiveSupport::TestCase
         'Thing'
       end
 
-      def yo(args = {})
+      def yo(_args = {})
         :dude
       end
-    }
-    @namespaced_thing_class = Class.new {
+    end
+    @namespaced_thing_class = Class.new do
       extend Nunes::Instrumentable
 
       def self.name
         'Some::Thing'
       end
 
-      def yo(args = {})
+      def yo(_args = {})
         :dude
       end
-    }
+    end
   end
 
   def teardown_class
@@ -52,31 +54,31 @@ class InstrumentationTest < ActiveSupport::TestCase
     @namespaced_thing_class = nil
   end
 
-  test "adds methods when extended" do
+  test 'adds methods when extended' do
     assert thing_class.respond_to?(:instrument_method_time)
   end
 
-  test "attempting to instrument time for method twice" do
+  test 'attempting to instrument time for method twice' do
     thing_class.instrument_method_time :yo
 
-    assert_raises(ArgumentError, "already instrumented yo for Thing") do
+    assert_raises(ArgumentError, 'already instrumented yo for Thing') do
       thing_class.instrument_method_time :yo
     end
   end
 
-  test "instrument_method_time" do
+  test 'instrument_method_time' do
     thing_class.instrument_method_time :yo
 
     event = slurp_events { thing_class.new.yo(some: 'thing') }.last
 
-    assert_not_nil event, "No events were found."
-    assert_equal "thing.yo", event.payload[:metric]
+    assert_not_nil event, 'No events were found.'
+    assert_equal 'thing.yo', event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
-    assert_timer "Thing.yo"
+    assert_timer 'Thing.yo'
   end
 
-  test "instrument_method_time for class method without full metric name" do
+  test 'instrument_method_time for class method without full metric name' do
     # I'd really like to not do this, but I don't have a name for the class
     # which makes it hard to automatically set the name. If anyone has a fix,
     # let me know.
@@ -85,66 +87,66 @@ class InstrumentationTest < ActiveSupport::TestCase
     end
   end
 
-  test "instrument_method_time for class method" do
-    thing_class.singleton_class.instrument_method_time :find, "Thing.find"
+  test 'instrument_method_time for class method' do
+    thing_class.singleton_class.instrument_method_time :find, 'Thing.find'
 
     event = slurp_events { thing_class.find(1) }.last
 
-    assert_not_nil event, "No events were found."
-    assert_equal "Thing.find", event.payload[:metric]
+    assert_not_nil event, 'No events were found.'
+    assert_equal 'Thing.find', event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
-    assert_timer "Thing.find"
+    assert_timer 'Thing.find'
   end
 
-  test "instrument_method_time with custom name in hash" do
+  test 'instrument_method_time with custom name in hash' do
     thing_class.instrument_method_time :yo, name: 'Thingy.yohoho'
 
     event = slurp_events { thing_class.new.yo(some: 'thing') }.last
 
-    assert_not_nil event, "No events were found."
-    assert_equal "Thingy.yohoho", event.payload[:metric]
+    assert_not_nil event, 'No events were found.'
+    assert_equal 'Thingy.yohoho', event.payload[:metric]
 
-    assert_timer "Thingy.yohoho"
+    assert_timer 'Thingy.yohoho'
   end
 
-  test "instrument_method_time with custom name as string" do
+  test 'instrument_method_time with custom name as string' do
     thing_class.instrument_method_time :yo, 'Thingy.yohoho'
 
     event = slurp_events { thing_class.new.yo(some: 'thing') }.last
 
-    assert_not_nil event, "No events were found."
-    assert_equal "Thingy.yohoho", event.payload[:metric]
+    assert_not_nil event, 'No events were found.'
+    assert_equal 'Thingy.yohoho', event.payload[:metric]
 
-    assert_timer "Thingy.yohoho"
+    assert_timer 'Thingy.yohoho'
   end
 
-  test "instrument_method_time with custom payload" do
-    thing_class.instrument_method_time :yo, payload: {pay: "loadin"}
+  test 'instrument_method_time with custom payload' do
+    thing_class.instrument_method_time :yo, payload: { pay: 'loadin' }
 
     event = slurp_events { thing_class.new.yo(some: 'thing') }.last
 
-    assert_not_nil event, "No events were found."
-    assert_equal "loadin", event.payload[:pay]
+    assert_not_nil event, 'No events were found.'
+    assert_equal 'loadin', event.payload[:pay]
 
-    assert_timer "thing.yo"
+    assert_timer 'thing.yo'
   end
 
-  test "instrument_method_time for namespaced class" do
+  test 'instrument_method_time for namespaced class' do
     namespaced_thing_class.instrument_method_time :yo
 
     event = slurp_events { namespaced_thing_class.new.yo(some: 'thing') }.last
 
-    assert_not_nil event, "No events were found."
-    assert_equal "some-Thing.yo", event.payload[:metric]
+    assert_not_nil event, 'No events were found.'
+    assert_equal 'some-Thing.yo', event.payload[:metric]
     assert event.duration > 0, "Expected #{event.duration} to be greater than 0"
 
-    assert_timer "Some-Thing.yo"
+    assert_timer 'Some-Thing.yo'
   end
 
   def slurp_events(&block)
     events = []
-    callback = lambda { |*args| events << ActiveSupport::Notifications::Event.new(*args) }
+    callback = ->(*args) { events << ActiveSupport::Notifications::Event.new(*args) }
     ActiveSupport::Notifications.subscribed(callback, Nunes::Instrumentable::MethodTimeEventName, &block)
     events
   end

--- a/test/job_instrumentation_test.rb
+++ b/test/job_instrumentation_test.rb
@@ -20,7 +20,12 @@ class JobInstrumentationTest < ActiveSupport::TestCase
     post = Post.new(title: 'Testing')
     SpamDetectorJob.perform_now(post)
 
-    assert_timer 'active_job.SpamDetectorJob.perform'
+    expected_tags = {
+      job: 'spam_detector_job',
+      queue: 'default'
+    }
+
+    assert_timer 'active_job.perform.duration.milliseconds', tags: expected_tags
   end
 
   test 'perform_later' do
@@ -29,7 +34,12 @@ class JobInstrumentationTest < ActiveSupport::TestCase
       SpamDetectorJob.perform_later(post)
     end
 
-    assert_counter 'active_job.SpamDetectorJob.enqueue'
-    assert_timer   'active_job.SpamDetectorJob.perform'
+    expected_tags = {
+      job: 'spam_detector_job',
+      queue: 'default'
+    }
+
+    assert_counter 'active_job.enqueue.total', tags: expected_tags
+    assert_timer   'active_job.perform.duration.milliseconds', tags: expected_tags
   end
 end

--- a/test/job_instrumentation_test.rb
+++ b/test/job_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class JobInstrumentationTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -14,20 +16,20 @@ class JobInstrumentationTest < ActiveSupport::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "perform_now" do
+  test 'perform_now' do
     post = Post.new(title: 'Testing')
     SpamDetectorJob.perform_now(post)
 
-    assert_timer   "active_job.SpamDetectorJob.perform"
+    assert_timer 'active_job.SpamDetectorJob.perform'
   end
 
-  test "perform_later" do
+  test 'perform_later' do
     post = Post.create!(title: 'Testing')
     perform_enqueued_jobs do
       SpamDetectorJob.perform_later(post)
     end
 
-    assert_counter "active_job.SpamDetectorJob.enqueue"
-    assert_timer   "active_job.SpamDetectorJob.perform"
+    assert_counter 'active_job.SpamDetectorJob.enqueue'
+    assert_timer   'active_job.SpamDetectorJob.perform'
   end
 end

--- a/test/mailer_instrumentation_test.rb
+++ b/test/mailer_instrumentation_test.rb
@@ -20,18 +20,19 @@ class MailerInstrumentationTest < ActionMailer::TestCase
 
   test 'deliver_now' do
     PostMailer.created.deliver_now
-    assert_timer 'action_mailer.deliver.PostMailer'
+    assert_timer 'action_mailer.deliver.duration.milliseconds', tags: { mailer: 'post_mailer' }
   end
 
   test 'deliver_later' do
     perform_enqueued_jobs do
       PostMailer.created.deliver_later
     end
-    assert_timer 'action_mailer.deliver.PostMailer'
+    assert_timer 'action_mailer.deliver.duration.milliseconds', tags: { mailer: 'post_mailer' }
   end
 
   test 'receive' do
     PostMailer.receive PostMailer.created
-    assert_timer 'action_mailer.receive.PostMailer'
+
+    assert_timer 'action_mailer.receive.duration.milliseconds', tags: { mailer: 'post_mailer' }
   end
 end

--- a/test/mailer_instrumentation_test.rb
+++ b/test/mailer_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class MailerInstrumentationTest < ActionMailer::TestCase
   include ActiveJob::TestHelper
@@ -16,20 +18,20 @@ class MailerInstrumentationTest < ActionMailer::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "deliver_now" do
+  test 'deliver_now' do
     PostMailer.created.deliver_now
-    assert_timer "action_mailer.deliver.PostMailer"
+    assert_timer 'action_mailer.deliver.PostMailer'
   end
 
-  test "deliver_later" do
+  test 'deliver_later' do
     perform_enqueued_jobs do
       PostMailer.created.deliver_later
     end
-    assert_timer "action_mailer.deliver.PostMailer"
+    assert_timer 'action_mailer.deliver.PostMailer'
   end
 
-  test "receive" do
+  test 'receive' do
     PostMailer.receive PostMailer.created
-    assert_timer "action_mailer.receive.PostMailer"
+    assert_timer 'action_mailer.receive.PostMailer'
   end
 end

--- a/test/model_instrumentation_test.rb
+++ b/test/model_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class ModelInstrumentationTest < ActiveSupport::TestCase
   setup :setup_subscriber
@@ -12,44 +14,44 @@ class ModelInstrumentationTest < ActiveSupport::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "transaction" do
+  test 'transaction' do
     Post.create(title: 'Testing')
 
-    assert_timer "active_record.sql.transaction_begin"
-    assert_timer "active_record.sql.transaction_commit"
+    assert_timer 'active_record.sql.transaction_begin'
+    assert_timer 'active_record.sql.transaction_commit'
   end
 
-  test "create" do
+  test 'create' do
     Post.create(title: 'Testing')
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.insert"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.insert'
   end
 
-  test "update" do
+  test 'update' do
     post = Post.create
     adapter.clear
-    post.update_attributes(title: "Title")
+    post.update_attributes(title: 'Title')
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.update"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.update'
   end
 
-  test "find" do
+  test 'find' do
     post = Post.create
     adapter.clear
     Post.find(post.id)
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.select"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.select'
   end
 
-  test "destroy" do
+  test 'destroy' do
     post = Post.create
     adapter.clear
     post.destroy
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.delete"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.delete'
   end
 end

--- a/test/model_instrumentation_test.rb
+++ b/test/model_instrumentation_test.rb
@@ -17,15 +17,14 @@ class ModelInstrumentationTest < ActiveSupport::TestCase
   test 'transaction' do
     Post.create(title: 'Testing')
 
-    assert_timer 'active_record.sql.transaction_begin'
-    assert_timer 'active_record.sql.transaction_commit'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'begin' }
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'commit' }
   end
 
   test 'create' do
     Post.create(title: 'Testing')
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.insert'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'insert' }
   end
 
   test 'update' do
@@ -33,8 +32,7 @@ class ModelInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     post.update_attributes(title: 'Title')
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.update'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'update' }
   end
 
   test 'find' do
@@ -42,8 +40,7 @@ class ModelInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     Post.find(post.id)
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.select'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'select' }
   end
 
   test 'destroy' do
@@ -51,7 +48,6 @@ class ModelInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     post.destroy
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.delete'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'delete' }
   end
 end

--- a/test/namespaced_controller_instrumentation_test.rb
+++ b/test/namespaced_controller_instrumentation_test.rb
@@ -22,6 +22,7 @@ class NamespacedControllerInstrumentationTest < ActionController::TestCase
     assert_response :success
 
     expected_tags = {
+      foo: 'bar',
       status: 200,
       controller: 'admin_posts_controller',
       action: 'index'

--- a/test/namespaced_controller_instrumentation_test.rb
+++ b/test/namespaced_controller_instrumentation_test.rb
@@ -21,21 +21,17 @@ class NamespacedControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :success
 
-    assert_timer 'action_controller.controller.Admin-PostsController.index.runtime.total'
-    assert_timer 'action_controller.controller.Admin-PostsController.index.runtime.view'
-    assert_timer 'action_controller.controller.Admin-PostsController.index.runtime.db'
+    expected_tags = {
+      status: 200,
+      controller: 'admin_posts_controller',
+      action: 'index'
+    }
 
-    assert_counter 'action_controller.format.html'
-    assert_counter 'action_controller.status.200'
+    assert_counter 'action_controller.requests.total', tags: expected_tags
 
-    assert_counter 'action_controller.controller.Admin-PostsController.index.format.html'
-    assert_counter 'action_controller.controller.Admin-PostsController.index.status.200'
-  end
-
-  test 'process_action w/ json' do
-    get :index, format: :json
-
-    assert_counter 'action_controller.controller.Admin-PostsController.index.format.json'
+    assert_timer 'action_controller.request.duration.milliseconds', tags: expected_tags
+    assert_timer 'action_controller.db.duration.milliseconds', tags: expected_tags
+    assert_timer 'action_controller.render.duration.milliseconds', tags: expected_tags
   end
 
   test 'process_action bad_request' do
@@ -43,6 +39,15 @@ class NamespacedControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :forbidden
 
-    assert_counter 'action_controller.controller.Admin-PostsController.new.status.403'
+    expected_tags = {
+      status: 403,
+      controller: 'admin_posts_controller',
+      action: 'new'
+    }
+
+    assert_counter 'action_controller.requests.total', tags: expected_tags
+
+    assert_timer 'action_controller.request.duration.milliseconds', tags: expected_tags
+    assert_timer 'action_controller.db.duration.milliseconds', tags: expected_tags
   end
 end

--- a/test/namespaced_controller_instrumentation_test.rb
+++ b/test/namespaced_controller_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class NamespacedControllerInstrumentationTest < ActionController::TestCase
   tests Admin::PostsController
@@ -14,33 +16,33 @@ class NamespacedControllerInstrumentationTest < ActionController::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "process_action" do
+  test 'process_action' do
     get :index
 
     assert_response :success
 
-    assert_timer "action_controller.controller.Admin-PostsController.index.runtime.total"
-    assert_timer "action_controller.controller.Admin-PostsController.index.runtime.view"
-    assert_timer "action_controller.controller.Admin-PostsController.index.runtime.db"
+    assert_timer 'action_controller.controller.Admin-PostsController.index.runtime.total'
+    assert_timer 'action_controller.controller.Admin-PostsController.index.runtime.view'
+    assert_timer 'action_controller.controller.Admin-PostsController.index.runtime.db'
 
-    assert_counter "action_controller.format.html"
-    assert_counter "action_controller.status.200"
+    assert_counter 'action_controller.format.html'
+    assert_counter 'action_controller.status.200'
 
-    assert_counter "action_controller.controller.Admin-PostsController.index.format.html"
-    assert_counter "action_controller.controller.Admin-PostsController.index.status.200"
+    assert_counter 'action_controller.controller.Admin-PostsController.index.format.html'
+    assert_counter 'action_controller.controller.Admin-PostsController.index.status.200'
   end
 
-  test "process_action w/ json" do
+  test 'process_action w/ json' do
     get :index, format: :json
 
-    assert_counter "action_controller.controller.Admin-PostsController.index.format.json"
+    assert_counter 'action_controller.controller.Admin-PostsController.index.format.json'
   end
 
-  test "process_action bad_request" do
+  test 'process_action bad_request' do
     get :new
 
     assert_response :forbidden
 
-    assert_counter "action_controller.controller.Admin-PostsController.new.status.403"
+    assert_counter 'action_controller.controller.Admin-PostsController.new.status.403'
   end
 end

--- a/test/namespaced_job_instrumentation_test.rb
+++ b/test/namespaced_job_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class NamespacedJobInstrumentationTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -14,20 +16,20 @@ class NamespacedJobInstrumentationTest < ActiveSupport::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "perform_now" do
+  test 'perform_now' do
     post = Post.new(title: 'Testing')
     Spam::DetectorJob.perform_now(post)
 
-    assert_timer   "active_job.Spam-DetectorJob.perform"
+    assert_timer 'active_job.Spam-DetectorJob.perform'
   end
 
-  test "perform_later" do
+  test 'perform_later' do
     post = Post.create!(title: 'Testing')
     perform_enqueued_jobs do
       Spam::DetectorJob.perform_later(post)
     end
 
-    assert_counter "active_job.Spam-DetectorJob.enqueue"
-    assert_timer   "active_job.Spam-DetectorJob.perform"
+    assert_counter 'active_job.Spam-DetectorJob.enqueue'
+    assert_timer   'active_job.Spam-DetectorJob.perform'
   end
 end

--- a/test/namespaced_job_instrumentation_test.rb
+++ b/test/namespaced_job_instrumentation_test.rb
@@ -20,7 +20,12 @@ class NamespacedJobInstrumentationTest < ActiveSupport::TestCase
     post = Post.new(title: 'Testing')
     Spam::DetectorJob.perform_now(post)
 
-    assert_timer 'active_job.Spam-DetectorJob.perform'
+    expected_tags = {
+      job: 'spam_detector_job',
+      queue: 'high'
+    }
+
+    assert_timer 'active_job.perform.duration.milliseconds', tags: expected_tags
   end
 
   test 'perform_later' do
@@ -29,7 +34,12 @@ class NamespacedJobInstrumentationTest < ActiveSupport::TestCase
       Spam::DetectorJob.perform_later(post)
     end
 
-    assert_counter 'active_job.Spam-DetectorJob.enqueue'
-    assert_timer   'active_job.Spam-DetectorJob.perform'
+    expected_tags = {
+      job: 'spam_detector_job',
+      queue: 'high'
+    }
+
+    assert_counter 'active_job.enqueue.total', tags: expected_tags
+    assert_timer   'active_job.perform.duration.milliseconds', tags: expected_tags
   end
 end

--- a/test/namespaced_mailer_instrumentation_test.rb
+++ b/test/namespaced_mailer_instrumentation_test.rb
@@ -20,18 +20,18 @@ class NamespacedMailerInstrumentationTest < ActionMailer::TestCase
 
   test 'deliver_now' do
     Admin::PostMailer.created.deliver_now
-    assert_timer 'action_mailer.deliver.Admin-PostMailer'
+    assert_timer 'action_mailer.deliver.duration.milliseconds', tags: { mailer: 'admin_post_mailer' }
   end
 
   test 'deliver_later' do
     perform_enqueued_jobs do
       Admin::PostMailer.created.deliver_later
     end
-    assert_timer 'action_mailer.deliver.Admin-PostMailer'
+    assert_timer 'action_mailer.deliver.duration.milliseconds', tags: { mailer: 'admin_post_mailer' }
   end
 
   test 'receive' do
     Admin::PostMailer.receive Admin::PostMailer.created
-    assert_timer 'action_mailer.receive.Admin-PostMailer'
+    assert_timer 'action_mailer.receive.duration.milliseconds', tags: { mailer: 'admin_post_mailer' }
   end
 end

--- a/test/namespaced_mailer_instrumentation_test.rb
+++ b/test/namespaced_mailer_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class NamespacedMailerInstrumentationTest < ActionMailer::TestCase
   include ActiveJob::TestHelper
@@ -16,20 +18,20 @@ class NamespacedMailerInstrumentationTest < ActionMailer::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "deliver_now" do
+  test 'deliver_now' do
     Admin::PostMailer.created.deliver_now
-    assert_timer "action_mailer.deliver.Admin-PostMailer"
+    assert_timer 'action_mailer.deliver.Admin-PostMailer'
   end
 
-  test "deliver_later" do
+  test 'deliver_later' do
     perform_enqueued_jobs do
       Admin::PostMailer.created.deliver_later
     end
-    assert_timer "action_mailer.deliver.Admin-PostMailer"
+    assert_timer 'action_mailer.deliver.Admin-PostMailer'
   end
 
-  test "receive" do
+  test 'receive' do
     Admin::PostMailer.receive Admin::PostMailer.created
-    assert_timer "action_mailer.receive.Admin-PostMailer"
+    assert_timer 'action_mailer.receive.Admin-PostMailer'
   end
 end

--- a/test/namespaced_model_instrumentation_test.rb
+++ b/test/namespaced_model_instrumentation_test.rb
@@ -17,15 +17,14 @@ class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
   test 'transaction' do
     Admin::Post.create(title: 'Testing')
 
-    assert_timer 'active_record.sql.transaction_begin'
-    assert_timer 'active_record.sql.transaction_commit'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'begin' }
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'commit' }
   end
 
   test 'create' do
     Admin::Post.create(title: 'Testing')
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.insert'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'insert' }
   end
 
   test 'update' do
@@ -33,8 +32,7 @@ class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     post.update_attributes(title: 'Title')
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.update'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'update' }
   end
 
   test 'find' do
@@ -42,8 +40,7 @@ class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     Admin::Post.find(post.id)
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.select'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'select' }
   end
 
   test 'destroy' do
@@ -51,7 +48,6 @@ class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
     adapter.clear
     post.destroy
 
-    assert_timer 'active_record.sql'
-    assert_timer 'active_record.sql.delete'
+    assert_timer 'active_record.sql.duration.milliseconds', tags: { operation: 'delete' }
   end
 end

--- a/test/namespaced_model_instrumentation_test.rb
+++ b/test/namespaced_model_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
   setup :setup_subscriber
@@ -12,44 +14,44 @@ class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "transaction" do
+  test 'transaction' do
     Admin::Post.create(title: 'Testing')
 
-    assert_timer "active_record.sql.transaction_begin"
-    assert_timer "active_record.sql.transaction_commit"
+    assert_timer 'active_record.sql.transaction_begin'
+    assert_timer 'active_record.sql.transaction_commit'
   end
 
-  test "create" do
+  test 'create' do
     Admin::Post.create(title: 'Testing')
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.insert"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.insert'
   end
 
-  test "update" do
+  test 'update' do
     post = Admin::Post.create
     adapter.clear
-    post.update_attributes(title: "Title")
+    post.update_attributes(title: 'Title')
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.update"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.update'
   end
 
-  test "find" do
+  test 'find' do
     post = Admin::Post.create
     adapter.clear
     Admin::Post.find(post.id)
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.select"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.select'
   end
 
-  test "destroy" do
+  test 'destroy' do
     post = Admin::Post.create
     adapter.clear
     post.destroy
 
-    assert_timer "active_record.sql"
-    assert_timer "active_record.sql.delete"
+    assert_timer 'active_record.sql'
+    assert_timer 'active_record.sql.delete'
   end
 end

--- a/test/nunes_test.rb
+++ b/test/nunes_test.rb
@@ -22,9 +22,9 @@ class NunesTest < ActiveSupport::TestCase
 
   test 'class_to_metric' do
     assert_nil Nunes.class_to_metric(nil)
-    assert_equal 'Foo', Nunes.class_to_metric('Foo')
-    assert_equal 'Nunes', Nunes.class_to_metric(Nunes)
-    assert_equal 'Spam-DetectorJob', Nunes.class_to_metric(Spam::DetectorJob)
-    assert_equal 'Spam-DetectorJob', Nunes.class_to_metric('Spam::DetectorJob')
+    assert_equal 'foo', Nunes.class_to_metric('Foo')
+    assert_equal 'nunes', Nunes.class_to_metric(Nunes)
+    assert_equal 'spam_detector_job', Nunes.class_to_metric(Spam::DetectorJob)
+    assert_equal 'spam_detector_job', Nunes.class_to_metric('Spam::DetectorJob')
   end
 end

--- a/test/nunes_test.rb
+++ b/test/nunes_test.rb
@@ -1,7 +1,9 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class NunesTest < ActiveSupport::TestCase
-  test "subscribe" do
+  test 'subscribe' do
     begin
       subscribers = Nunes.subscribe(adapter)
       assert_instance_of Array, subscribers
@@ -18,11 +20,11 @@ class NunesTest < ActiveSupport::TestCase
     end
   end
 
-  test "class_to_metric" do
+  test 'class_to_metric' do
     assert_nil Nunes.class_to_metric(nil)
-    assert_equal "Foo", Nunes.class_to_metric("Foo")
-    assert_equal "Nunes", Nunes.class_to_metric(Nunes)
-    assert_equal "Spam-DetectorJob", Nunes.class_to_metric(Spam::DetectorJob)
-    assert_equal "Spam-DetectorJob", Nunes.class_to_metric("Spam::DetectorJob")
+    assert_equal 'Foo', Nunes.class_to_metric('Foo')
+    assert_equal 'Nunes', Nunes.class_to_metric(Nunes)
+    assert_equal 'Spam-DetectorJob', Nunes.class_to_metric(Spam::DetectorJob)
+    assert_equal 'Spam-DetectorJob', Nunes.class_to_metric('Spam::DetectorJob')
   end
 end

--- a/test/rails_app_4.2.5/Rakefile
+++ b/test/rails_app_4.2.5/Rakefile
@@ -1,7 +1,9 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 RailsApp::Application.load_tasks

--- a/test/rails_app_4.2.5/app/controllers/admin/posts_controller.rb
+++ b/test/rails_app_4.2.5/app/controllers/admin/posts_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class Admin::PostsController < ApplicationController
   def index
     @posts = Post.all
 
     respond_to do |format|
       format.html { render }
-      format.json { render :json => @posts }
+      format.json { render json: @posts }
     end
   end
 

--- a/test/rails_app_4.2.5/app/controllers/application_controller.rb
+++ b/test/rails_app_4.2.5/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery
 end

--- a/test/rails_app_4.2.5/app/controllers/application_controller.rb
+++ b/test/rails_app_4.2.5/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery
+
+  def append_info_to_payload(payload)
+    super
+    payload[:tags] = { foo: 'bar' } if payload[:action] == 'index'
+  end
 end

--- a/test/rails_app_4.2.5/app/controllers/posts_controller.rb
+++ b/test/rails_app_4.2.5/app/controllers/posts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostsController < ApplicationController
   def index
     @posts = Post.all
@@ -17,6 +19,6 @@ class PostsController < ApplicationController
   end
 
   def some_boom
-    raise "boom!"
+    raise 'boom!'
   end
 end

--- a/test/rails_app_4.2.5/app/helpers/application_helper.rb
+++ b/test/rails_app_4.2.5/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/rails_app_4.2.5/app/jobs/spam/detector_job.rb
+++ b/test/rails_app_4.2.5/app/jobs/spam/detector_job.rb
@@ -2,7 +2,7 @@
 
 module Spam
   class DetectorJob < ActiveJob::Base
-    queue_as :default
+    queue_as :high
 
     def perform(*posts)
       posts.detect do |post|

--- a/test/rails_app_4.2.5/app/jobs/spam/detector_job.rb
+++ b/test/rails_app_4.2.5/app/jobs/spam/detector_job.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Spam
   class DetectorJob < ActiveJob::Base
     queue_as :default
 
     def perform(*posts)
       posts.detect do |post|
-        post.title.include?("Buy watches cheap!")
+        post.title.include?('Buy watches cheap!')
       end
     end
   end

--- a/test/rails_app_4.2.5/app/jobs/spam_detector_job.rb
+++ b/test/rails_app_4.2.5/app/jobs/spam_detector_job.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class SpamDetectorJob < ActiveJob::Base
   queue_as :default
 
   def perform(*posts)
     posts.detect do |post|
-      post.title.include?("Buy watches cheap!")
+      post.title.include?('Buy watches cheap!')
     end
   end
 end

--- a/test/rails_app_4.2.5/app/mailers/admin/post_mailer.rb
+++ b/test/rails_app_4.2.5/app/mailers/admin/post_mailer.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Admin
   class PostMailer < ActionMailer::Base
-    default from: "from@example.com"
+    default from: 'from@example.com'
 
     def created
-      mail to: "to@example.org"
+      mail to: 'to@example.org'
     end
 
     def receive(email)

--- a/test/rails_app_4.2.5/app/mailers/post_mailer.rb
+++ b/test/rails_app_4.2.5/app/mailers/post_mailer.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class PostMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: 'from@example.com'
 
   def created
-    mail to: "to@example.org"
+    mail to: 'to@example.org'
   end
 
   def receive(email)

--- a/test/rails_app_4.2.5/app/models/admin/post.rb
+++ b/test/rails_app_4.2.5/app/models/admin/post.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Admin
   class Post < ActiveRecord::Base
-    self.table_name = "posts"
+    self.table_name = 'posts'
   end
 end

--- a/test/rails_app_4.2.5/app/models/post.rb
+++ b/test/rails_app_4.2.5/app/models/post.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Post < ActiveRecord::Base
 end

--- a/test/rails_app_4.2.5/config.ru
+++ b/test/rails_app_4.2.5/config.ru
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run RailsApp::Application

--- a/test/rails_app_4.2.5/config/application.rb
+++ b/test/rails_app_4.2.5/config/application.rb
@@ -1,15 +1,17 @@
-require File.expand_path('../boot', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('boot', __dir__)
 
 # Pick the frameworks you want:
-require "active_record/railtie"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "sprockets/railtie"
-require "rails/test_unit/railtie"
+require 'active_record/railtie'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'sprockets/railtie'
+require 'rails/test_unit/railtie'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
+  Bundler.require(*Rails.groups(assets: %w[development test]))
   # If you want your assets lazily compiled in production, use this line
   # Bundler.require(:default, :assets, Rails.env)
 end
@@ -39,7 +41,7 @@ module RailsApp
     # config.i18n.default_locale = :de
 
     # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = "utf-8"
+    config.encoding = 'utf-8'
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]

--- a/test/rails_app_4.2.5/config/boot.rb
+++ b/test/rails_app_4.2.5/config/boot.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/test/rails_app_4.2.5/config/environment.rb
+++ b/test/rails_app_4.2.5/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the rails application
-require File.expand_path('../application', __FILE__)
+require File.expand_path('application', __dir__)
 
 # Initialize the rails application
 RailsApp::Application.initialize!

--- a/test/rails_app_4.2.5/config/environments/development.rb
+++ b/test/rails_app_4.2.5/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RailsApp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
@@ -21,7 +23,6 @@ RailsApp::Application.configure do
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
-
 
   # Do not compress assets
   config.assets.compress = false

--- a/test/rails_app_4.2.5/config/environments/production.rb
+++ b/test/rails_app_4.2.5/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RailsApp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
@@ -60,5 +62,4 @@ RailsApp::Application.configure do
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
-
 end

--- a/test/rails_app_4.2.5/config/environments/test.rb
+++ b/test/rails_app_4.2.5/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RailsApp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
@@ -9,7 +11,7 @@ RailsApp::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_files = true
-  config.static_cache_control = "public, max-age=3600"
+  config.static_cache_control = 'public, max-age=3600'
 
   # Log error messages when you accidentally call methods on nil
   config.whiny_nils = true
@@ -23,15 +25,13 @@ RailsApp::Application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
+  config.action_controller.allow_forgery_protection = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.active_support.test_order = :random
-
-
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr

--- a/test/rails_app_4.2.5/config/initializers/backtrace_silencers.rb
+++ b/test/rails_app_4.2.5/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/rails_app_4.2.5/config/initializers/force_test_schema_load.rb
+++ b/test/rails_app_4.2.5/config/initializers/force_test_schema_load.rb
@@ -1,3 +1,3 @@
-if Rails.env.test?
-  load "#{Rails.root}/db/schema.rb"
-end
+# frozen_string_literal: true
+
+load "#{Rails.root}/db/schema.rb" if Rails.env.test?

--- a/test/rails_app_4.2.5/config/initializers/inflections.rb
+++ b/test/rails_app_4.2.5/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/test/rails_app_4.2.5/config/initializers/mime_types.rb
+++ b/test/rails_app_4.2.5/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/rails_app_4.2.5/config/initializers/secret_token.rb
+++ b/test/rails_app_4.2.5/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/test/rails_app_4.2.5/config/initializers/session_store.rb
+++ b/test/rails_app_4.2.5/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 RailsApp::Application.config.session_store :cookie_store, key: '_rails_app_session'

--- a/test/rails_app_4.2.5/config/initializers/wrap_parameters.rb
+++ b/test/rails_app_4.2.5/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains settings for ActionController::ParamsWrapper which
@@ -7,4 +9,3 @@
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json]
 end
-

--- a/test/rails_app_4.2.5/config/routes.rb
+++ b/test/rails_app_4.2.5/config/routes.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 RailsApp::Application.routes.draw do
   namespace :admin do
-    resources :posts, only: [:index, :new]
+    resources :posts, only: %i[index new]
   end
 
   resources :posts, only: :index
 
-  get "/some-data",     to: "posts#some_data"
-  get "/some-file",     to: "posts#some_file"
-  get "/some-redirect", to: "posts#some_redirect"
-  get "/some-boom",     to: "posts#some_boom"
+  get '/some-data',     to: 'posts#some_data'
+  get '/some-file',     to: 'posts#some_file'
+  get '/some-redirect', to: 'posts#some_redirect'
+  get '/some-boom',     to: 'posts#some_boom'
 end

--- a/test/rails_app_4.2.5/db/migrate/20130417154459_create_posts.rb
+++ b/test/rails_app_4.2.5/db/migrate/20130417154459_create_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePosts < ActiveRecord::Migration
   def change
     create_table :posts do |t|

--- a/test/rails_app_4.2.5/db/schema.rb
+++ b/test/rails_app_4.2.5/db/schema.rb
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,12 +12,10 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130417154459) do
-
-  create_table "posts", :force => true do |t|
-    t.string   "title"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+ActiveRecord::Schema.define(version: 20_130_417_154_459) do
+  create_table 'posts', force: true do |t|
+    t.string   'title'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
-
 end

--- a/test/rails_app_4.2.5/db/seeds.rb
+++ b/test/rails_app_4.2.5/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #

--- a/test/rails_app_4.2.5/script/rails
+++ b/test/rails_app_4.2.5/script/rails
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
+APP_PATH = File.expand_path('../config/application', __dir__)
+require File.expand_path('../config/boot', __dir__)
 require 'rails/commands'

--- a/test/rails_app_5.0.0/Gemfile
+++ b/test/rails_app_5.0.0/Gemfile
@@ -1,5 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
 
+source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.0'
@@ -37,12 +38,12 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'web-console'
   gem 'listen', '~> 3.0.5'
+  gem 'web-console'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/test/rails_app_5.0.0/Rakefile
+++ b/test/rails_app_5.0.0/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/test/rails_app_5.0.0/app/channels/application_cable/channel.rb
+++ b/test/rails_app_5.0.0/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/test/rails_app_5.0.0/app/channels/application_cable/connection.rb
+++ b/test/rails_app_5.0.0/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/test/rails_app_5.0.0/app/controllers/admin/posts_controller.rb
+++ b/test/rails_app_5.0.0/app/controllers/admin/posts_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class Admin::PostsController < ApplicationController
   def index
     @posts = Post.all
 
     respond_to do |format|
       format.html { render }
-      format.json { render :json => @posts }
+      format.json { render json: @posts }
     end
   end
 

--- a/test/rails_app_5.0.0/app/controllers/application_controller.rb
+++ b/test/rails_app_5.0.0/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 end

--- a/test/rails_app_5.0.0/app/controllers/application_controller.rb
+++ b/test/rails_app_5.0.0/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def append_info_to_payload(payload)
+    super
+    payload[:tags] = { foo: 'bar' } if payload[:action] == 'index'
+  end
 end

--- a/test/rails_app_5.0.0/app/controllers/posts_controller.rb
+++ b/test/rails_app_5.0.0/app/controllers/posts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostsController < ApplicationController
   def index
     @posts = Post.all
@@ -17,6 +19,6 @@ class PostsController < ApplicationController
   end
 
   def some_boom
-    raise "boom!"
+    raise 'boom!'
   end
 end

--- a/test/rails_app_5.0.0/app/helpers/application_helper.rb
+++ b/test/rails_app_5.0.0/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/rails_app_5.0.0/app/jobs/application_job.rb
+++ b/test/rails_app_5.0.0/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/test/rails_app_5.0.0/app/jobs/spam/detector_job.rb
+++ b/test/rails_app_5.0.0/app/jobs/spam/detector_job.rb
@@ -2,7 +2,7 @@
 
 module Spam
   class DetectorJob < ApplicationJob
-    queue_as :default
+    queue_as :high
 
     def perform(*posts)
       posts.detect do |post|

--- a/test/rails_app_5.0.0/app/jobs/spam/detector_job.rb
+++ b/test/rails_app_5.0.0/app/jobs/spam/detector_job.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Spam
   class DetectorJob < ApplicationJob
     queue_as :default
 
     def perform(*posts)
       posts.detect do |post|
-        post.title.include?("Buy watches cheap!")
+        post.title.include?('Buy watches cheap!')
       end
     end
   end

--- a/test/rails_app_5.0.0/app/jobs/spam_detector_job.rb
+++ b/test/rails_app_5.0.0/app/jobs/spam_detector_job.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class SpamDetectorJob < ApplicationJob
   queue_as :default
 
   def perform(*posts)
     posts.detect do |post|
-      post.title.include?("Buy watches cheap!")
+      post.title.include?('Buy watches cheap!')
     end
   end
 end

--- a/test/rails_app_5.0.0/app/mailers/admin/post_mailer.rb
+++ b/test/rails_app_5.0.0/app/mailers/admin/post_mailer.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Admin
   class PostMailer < ApplicationMailer
-    default from: "from@example.com"
+    default from: 'from@example.com'
 
     def created
-      mail to: "to@example.org"
+      mail to: 'to@example.org'
     end
 
     def receive(email)

--- a/test/rails_app_5.0.0/app/mailers/application_mailer.rb
+++ b/test/rails_app_5.0.0/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/test/rails_app_5.0.0/app/mailers/post_mailer.rb
+++ b/test/rails_app_5.0.0/app/mailers/post_mailer.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class PostMailer < ApplicationMailer
-  default from: "from@example.com"
+  default from: 'from@example.com'
 
   def created
-    mail to: "to@example.org"
+    mail to: 'to@example.org'
   end
 
   def receive(email)

--- a/test/rails_app_5.0.0/app/models/admin/post.rb
+++ b/test/rails_app_5.0.0/app/models/admin/post.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Admin
   class Post < ApplicationRecord
-    self.table_name = "posts"
+    self.table_name = 'posts'
   end
 end

--- a/test/rails_app_5.0.0/app/models/application_record.rb
+++ b/test/rails_app_5.0.0/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/test/rails_app_5.0.0/app/models/post.rb
+++ b/test/rails_app_5.0.0/app/models/post.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Post < ApplicationRecord
 end

--- a/test/rails_app_5.0.0/bin/bundle
+++ b/test/rails_app_5.0.0/bin/bundle
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+# frozen_string_literal: true
+
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/test/rails_app_5.0.0/bin/rails
+++ b/test/rails_app_5.0.0/bin/rails
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/test/rails_app_5.0.0/bin/rake
+++ b/test/rails_app_5.0.0/bin/rake
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/test/rails_app_5.0.0/bin/setup
+++ b/test/rails_app_5.0.0/bin/setup
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/test/rails_app_5.0.0/bin/spring
+++ b/test/rails_app_5.0.0/bin/spring
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.

--- a/test/rails_app_5.0.0/bin/update
+++ b/test/rails_app_5.0.0/bin/update
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/test/rails_app_5.0.0/config.ru
+++ b/test/rails_app_5.0.0/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/test/rails_app_5.0.0/config/application.rb
+++ b/test/rails_app_5.0.0/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'rails/all'

--- a/test/rails_app_5.0.0/config/boot.rb
+++ b/test/rails_app_5.0.0/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/test/rails_app_5.0.0/config/environment.rb
+++ b/test/rails_app_5.0.0/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/test/rails_app_5.0.0/config/environments/development.rb
+++ b/test/rails_app_5.0.0/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/rails_app_5.0.0/config/environments/production.rb
+++ b/test/rails_app_5.0.0/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -47,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -75,7 +77,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)

--- a/test/rails_app_5.0.0/config/environments/test.rb
+++ b/test/rails_app_5.0.0/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/rails_app_5.0.0/config/initializers/application_controller_renderer.rb
+++ b/test/rails_app_5.0.0/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ApplicationController.renderer.defaults.merge!(

--- a/test/rails_app_5.0.0/config/initializers/assets.rb
+++ b/test/rails_app_5.0.0/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/test/rails_app_5.0.0/config/initializers/backtrace_silencers.rb
+++ b/test/rails_app_5.0.0/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/rails_app_5.0.0/config/initializers/cookies_serializer.rb
+++ b/test/rails_app_5.0.0/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/test/rails_app_5.0.0/config/initializers/filter_parameter_logging.rb
+++ b/test/rails_app_5.0.0/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/rails_app_5.0.0/config/initializers/force_test_schema_load.rb
+++ b/test/rails_app_5.0.0/config/initializers/force_test_schema_load.rb
@@ -1,3 +1,3 @@
-if Rails.env.test?
-  load "#{Rails.root}/db/schema.rb"
-end
+# frozen_string_literal: true
+
+load "#{Rails.root}/db/schema.rb" if Rails.env.test?

--- a/test/rails_app_5.0.0/config/initializers/inflections.rb
+++ b/test/rails_app_5.0.0/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/rails_app_5.0.0/config/initializers/mime_types.rb
+++ b/test/rails_app_5.0.0/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/rails_app_5.0.0/config/initializers/new_framework_defaults.rb
+++ b/test/rails_app_5.0.0/config/initializers/new_framework_defaults.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.

--- a/test/rails_app_5.0.0/config/initializers/session_store.rb
+++ b/test/rails_app_5.0.0/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_rails_app_session'

--- a/test/rails_app_5.0.0/config/initializers/wrap_parameters.rb
+++ b/test/rails_app_5.0.0/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/rails_app_5.0.0/config/puma.rb
+++ b/test/rails_app_5.0.0/config/puma.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/test/rails_app_5.0.0/config/routes.rb
+++ b/test/rails_app_5.0.0/config/routes.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   namespace :admin do
-    resources :posts, only: [:index, :new]
+    resources :posts, only: %i[index new]
   end
 
   resources :posts, only: :index
 
-  get "/some-data",     to: "posts#some_data"
-  get "/some-file",     to: "posts#some_file"
-  get "/some-redirect", to: "posts#some_redirect"
-  get "/some-boom",     to: "posts#some_boom"
+  get '/some-data',     to: 'posts#some_data'
+  get '/some-file',     to: 'posts#some_file'
+  get '/some-redirect', to: 'posts#some_redirect'
+  get '/some-boom',     to: 'posts#some_boom'
 end

--- a/test/rails_app_5.0.0/config/spring.rb
+++ b/test/rails_app_5.0.0/config/spring.rb
@@ -1,6 +1,8 @@
-%w(
+# frozen_string_literal: true
+
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/test/rails_app_5.0.0/db/migrate/20160812134213_create_posts.rb
+++ b/test/rails_app_5.0.0/db/migrate/20160812134213_create_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePosts < ActiveRecord::Migration[5.0]
   def change
     create_table :posts do |t|

--- a/test/rails_app_5.0.0/db/schema.rb
+++ b/test/rails_app_5.0.0/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,12 +12,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160812134213) do
-
-  create_table "posts", force: :cascade do |t|
-    t.string   "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+ActiveRecord::Schema.define(version: 20_160_812_134_213) do
+  create_table 'posts', force: :cascade do |t|
+    t.string   'title'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
-
 end

--- a/test/rails_app_5.0.0/db/seeds.rb
+++ b/test/rails_app_5.0.0/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #

--- a/test/rails_app_5.0.0/test/test_helper.rb
+++ b/test/rails_app_5.0.0/test/test_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase

--- a/test/rails_app_5.1.4/Gemfile
+++ b/test/rails_app_5.1.4/Gemfile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"
 end
-
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'
@@ -35,7 +36,7 @@ gem 'jbuilder', '~> 2.5'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
@@ -43,12 +44,12 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/test/rails_app_5.1.4/Rakefile
+++ b/test/rails_app_5.1.4/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/test/rails_app_5.1.4/app/channels/application_cable/channel.rb
+++ b/test/rails_app_5.1.4/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/test/rails_app_5.1.4/app/channels/application_cable/connection.rb
+++ b/test/rails_app_5.1.4/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/test/rails_app_5.1.4/app/controllers/admin/posts_controller.rb
+++ b/test/rails_app_5.1.4/app/controllers/admin/posts_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class Admin::PostsController < ApplicationController
   def index
     @posts = Post.all
 
     respond_to do |format|
       format.html { render }
-      format.json { render :json => @posts }
+      format.json { render json: @posts }
     end
   end
 

--- a/test/rails_app_5.1.4/app/controllers/application_controller.rb
+++ b/test/rails_app_5.1.4/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 end

--- a/test/rails_app_5.1.4/app/controllers/application_controller.rb
+++ b/test/rails_app_5.1.4/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def append_info_to_payload(payload)
+    super
+    payload[:tags] = { foo: 'bar' } if payload[:action] == 'index'
+  end
 end

--- a/test/rails_app_5.1.4/app/controllers/posts_controller.rb
+++ b/test/rails_app_5.1.4/app/controllers/posts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostsController < ApplicationController
   def index
     @posts = Post.all
@@ -17,6 +19,6 @@ class PostsController < ApplicationController
   end
 
   def some_boom
-    raise "boom!"
+    raise 'boom!'
   end
 end

--- a/test/rails_app_5.1.4/app/helpers/application_helper.rb
+++ b/test/rails_app_5.1.4/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/rails_app_5.1.4/app/jobs/application_job.rb
+++ b/test/rails_app_5.1.4/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/test/rails_app_5.1.4/app/jobs/spam/detector_job.rb
+++ b/test/rails_app_5.1.4/app/jobs/spam/detector_job.rb
@@ -2,7 +2,7 @@
 
 module Spam
   class DetectorJob < ApplicationJob
-    queue_as :default
+    queue_as :high
 
     def perform(*posts)
       posts.detect do |post|

--- a/test/rails_app_5.1.4/app/jobs/spam/detector_job.rb
+++ b/test/rails_app_5.1.4/app/jobs/spam/detector_job.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Spam
   class DetectorJob < ApplicationJob
     queue_as :default
 
     def perform(*posts)
       posts.detect do |post|
-        post.title.include?("Buy watches cheap!")
+        post.title.include?('Buy watches cheap!')
       end
     end
   end

--- a/test/rails_app_5.1.4/app/jobs/spam_detector_job.rb
+++ b/test/rails_app_5.1.4/app/jobs/spam_detector_job.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class SpamDetectorJob < ApplicationJob
   queue_as :default
 
   def perform(*posts)
     posts.detect do |post|
-      post.title.include?("Buy watches cheap!")
+      post.title.include?('Buy watches cheap!')
     end
   end
 end

--- a/test/rails_app_5.1.4/app/mailers/admin/post_mailer.rb
+++ b/test/rails_app_5.1.4/app/mailers/admin/post_mailer.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Admin
   class PostMailer < ApplicationMailer
-    default from: "from@example.com"
+    default from: 'from@example.com'
 
     def created
-      mail to: "to@example.org"
+      mail to: 'to@example.org'
     end
 
     def receive(email)

--- a/test/rails_app_5.1.4/app/mailers/application_mailer.rb
+++ b/test/rails_app_5.1.4/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/test/rails_app_5.1.4/app/mailers/post_mailer.rb
+++ b/test/rails_app_5.1.4/app/mailers/post_mailer.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class PostMailer < ApplicationMailer
-  default from: "from@example.com"
+  default from: 'from@example.com'
 
   def created
-    mail to: "to@example.org"
+    mail to: 'to@example.org'
   end
 
   def receive(email)

--- a/test/rails_app_5.1.4/app/models/admin/post.rb
+++ b/test/rails_app_5.1.4/app/models/admin/post.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Admin
   class Post < ApplicationRecord
-    self.table_name = "posts"
+    self.table_name = 'posts'
   end
 end

--- a/test/rails_app_5.1.4/app/models/application_record.rb
+++ b/test/rails_app_5.1.4/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/test/rails_app_5.1.4/app/models/post.rb
+++ b/test/rails_app_5.1.4/app/models/post.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Post < ApplicationRecord
 end

--- a/test/rails_app_5.1.4/bin/bundle
+++ b/test/rails_app_5.1.4/bin/bundle
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+# frozen_string_literal: true
+
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/test/rails_app_5.1.4/bin/rails
+++ b/test/rails_app_5.1.4/bin/rails
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/test/rails_app_5.1.4/bin/rake
+++ b/test/rails_app_5.1.4/bin/rake
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/test/rails_app_5.1.4/bin/setup
+++ b/test/rails_app_5.1.4/bin/setup
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -20,7 +22,6 @@ chdir APP_ROOT do
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
-
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/test/rails_app_5.1.4/bin/spring
+++ b/test/rails_app_5.1.4/bin/spring
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
@@ -8,7 +9,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version

--- a/test/rails_app_5.1.4/bin/update
+++ b/test/rails_app_5.1.4/bin/update
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/test/rails_app_5.1.4/bin/yarn
+++ b/test/rails_app_5.1.4/bin/yarn
@@ -1,11 +1,13 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 VENDOR_PATH = File.expand_path('..', __dir__)
 Dir.chdir(VENDOR_PATH) do
   begin
-    exec "yarnpkg #{ARGV.join(" ")}"
+    exec "yarnpkg #{ARGV.join(' ')}"
   rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn 'Yarn executable was not detected in the system.'
+    warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
     exit 1
   end
 end

--- a/test/rails_app_5.1.4/config.ru
+++ b/test/rails_app_5.1.4/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/test/rails_app_5.1.4/config/application.rb
+++ b/test/rails_app_5.1.4/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'rails/all'

--- a/test/rails_app_5.1.4/config/boot.rb
+++ b/test/rails_app_5.1.4/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/test/rails_app_5.1.4/config/environment.rb
+++ b/test/rails_app_5.1.4/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/test/rails_app_5.1.4/config/environments/development.rb
+++ b/test/rails_app_5.1.4/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/rails_app_5.1.4/config/environments/production.rb
+++ b/test/rails_app_5.1.4/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -52,7 +54,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -80,7 +82,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/test/rails_app_5.1.4/config/environments/test.rb
+++ b/test/rails_app_5.1.4/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/rails_app_5.1.4/config/initializers/application_controller_renderer.rb
+++ b/test/rails_app_5.1.4/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/test/rails_app_5.1.4/config/initializers/assets.rb
+++ b/test/rails_app_5.1.4/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/test/rails_app_5.1.4/config/initializers/backtrace_silencers.rb
+++ b/test/rails_app_5.1.4/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/rails_app_5.1.4/config/initializers/cookies_serializer.rb
+++ b/test/rails_app_5.1.4/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/test/rails_app_5.1.4/config/initializers/filter_parameter_logging.rb
+++ b/test/rails_app_5.1.4/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/rails_app_5.1.4/config/initializers/force_test_schema_load.rb
+++ b/test/rails_app_5.1.4/config/initializers/force_test_schema_load.rb
@@ -1,3 +1,3 @@
-if Rails.env.test?
-  load "#{Rails.root}/db/schema.rb"
-end
+# frozen_string_literal: true
+
+load "#{Rails.root}/db/schema.rb" if Rails.env.test?

--- a/test/rails_app_5.1.4/config/initializers/inflections.rb
+++ b/test/rails_app_5.1.4/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/rails_app_5.1.4/config/initializers/mime_types.rb
+++ b/test/rails_app_5.1.4/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/rails_app_5.1.4/config/initializers/wrap_parameters.rb
+++ b/test/rails_app_5.1.4/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/rails_app_5.1.4/config/puma.rb
+++ b/test/rails_app_5.1.4/config/puma.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/test/rails_app_5.1.4/config/routes.rb
+++ b/test/rails_app_5.1.4/config/routes.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   namespace :admin do
-    resources :posts, only: [:index, :new]
+    resources :posts, only: %i[index new]
   end
 
   resources :posts, only: :index
 
-  get "/some-data",     to: "posts#some_data"
-  get "/some-file",     to: "posts#some_file"
-  get "/some-redirect", to: "posts#some_redirect"
-  get "/some-boom",     to: "posts#some_boom"
+  get '/some-data',     to: 'posts#some_data'
+  get '/some-file',     to: 'posts#some_file'
+  get '/some-redirect', to: 'posts#some_redirect'
+  get '/some-boom',     to: 'posts#some_boom'
 end

--- a/test/rails_app_5.1.4/config/spring.rb
+++ b/test/rails_app_5.1.4/config/spring.rb
@@ -1,6 +1,8 @@
-%w(
+# frozen_string_literal: true
+
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/test/rails_app_5.1.4/db/migrate/20160812134213_create_posts.rb
+++ b/test/rails_app_5.1.4/db/migrate/20160812134213_create_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePosts < ActiveRecord::Migration[5.0]
   def change
     create_table :posts do |t|

--- a/test/rails_app_5.1.4/db/schema.rb
+++ b/test/rails_app_5.1.4/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,12 +12,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160812134213) do
-
-  create_table "posts", force: :cascade do |t|
-    t.string "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+ActiveRecord::Schema.define(version: 20_160_812_134_213) do
+  create_table 'posts', force: :cascade do |t|
+    t.string 'title'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
-
 end

--- a/test/rails_app_5.1.4/db/seeds.rb
+++ b/test/rails_app_5.1.4/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #

--- a/test/rails_app_5.1.4/test/application_system_test_case.rb
+++ b/test/rails_app_5.1.4/test/application_system_test_case.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/rails_app_5.1.4/test/test_helper.rb
+++ b/test/rails_app_5.1.4/test/test_helper.rb
@@ -1,4 +1,6 @@
-require File.expand_path('../../config/environment', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -1,5 +1,7 @@
-require "helper"
-require "minitest/mock"
+# frozen_string_literal: true
+
+require 'helper'
+require 'minitest/mock'
 
 class SubscriberTest < ActiveSupport::TestCase
   attr_reader :subscriber_class
@@ -12,20 +14,20 @@ class SubscriberTest < ActiveSupport::TestCase
         /\.test\Z/
       end
 
-      def foo(*args)
-        increment "test.foo"
+      def foo(*_args)
+        increment 'test.foo'
       end
 
       # minitest stub works with call, so i change it to just return self, since
       # all we really want to test in this instance is that things are wired
       # up right, not that call dispatches events correctly
-      def call(*args)
+      def call(*_args)
         self
       end
     end
   end
 
-  test "subscribe" do
+  test 'subscribe' do
     client = {}
     instance = subscriber_class.new(client)
 
@@ -35,13 +37,13 @@ class SubscriberTest < ActiveSupport::TestCase
       mock.expect :subscribe, :subscriber, [subscriber_class.pattern, instance]
 
       assert_equal :subscriber,
-        subscriber_class.subscribe(adapter, subscriber: mock)
+                   subscriber_class.subscribe(adapter, subscriber: mock)
 
       mock.verify
     end
   end
 
-  test "initialize" do
+  test 'initialize' do
     adapter = Object.new
     Nunes::Adapter.stub :wrap, adapter do
       instance = subscriber_class.new({})

--- a/test/support/adapter_test_helpers.rb
+++ b/test/support/adapter_test_helpers.rb
@@ -23,8 +23,8 @@ module AdapterTestHelpers
     Post.delete_all
   end
 
-  def assert_timer(metric)
-    assert adapter.timer?(metric),
+  def assert_timer(metric, opts = {})
+    assert adapter.timer?(metric, opts),
            "Expected the timer #{metric.inspect} to be included in #{adapter.timer_metric_names.inspect}, but it was not."
   end
 
@@ -33,8 +33,8 @@ module AdapterTestHelpers
            "Expected the timer #{metric.inspect} to not be included in #{adapter.timer_metric_names.inspect}, but it was."
   end
 
-  def assert_counter(metric, _opts = { sample_rate: 1, tags: {} })
-    assert adapter.counter?(metric),
+  def assert_counter(metric, opts = {})
+    assert adapter.counter?(metric, opts),
            "Expected the counter #{metric.inspect} to be included in #{adapter.counter_metric_names.inspect}, but it was not."
   end
 

--- a/test/support/adapter_test_helpers.rb
+++ b/test/support/adapter_test_helpers.rb
@@ -24,8 +24,11 @@ module AdapterTestHelpers
   end
 
   def assert_timer(metric, opts = {})
-    assert adapter.timer?(metric, opts),
+    timers = adapter.timers.find_all { |timer| timer.first == metric }
+    assert timers.length.positive?
            "Expected the timer #{metric.inspect} to be included in #{adapter.timer_metric_names.inspect}, but it was not."
+    assert timers.find { |timer| timer.last == opts },
+           "Expected the options #{opts.inspect} to be included in #{timers.map(&:last)}"
   end
 
   def refute_timer(metric)
@@ -34,8 +37,11 @@ module AdapterTestHelpers
   end
 
   def assert_counter(metric, opts = {})
-    assert adapter.counter?(metric, opts),
+    counters = adapter.counters.find_all { |counter| counter.first == metric }
+    assert counters.length.positive?
            "Expected the counter #{metric.inspect} to be included in #{adapter.counter_metric_names.inspect}, but it was not."
+    assert counters.find { |counter| counter.last == opts },
+           "Expected the options #{opts.inspect} to be included in #{counters.map(&:last)}"
   end
 
   def refute_counter(metric)

--- a/test/support/adapter_test_helpers.rb
+++ b/test/support/adapter_test_helpers.rb
@@ -31,7 +31,7 @@ module AdapterTestHelpers
       "Expected the timer #{metric.inspect} to not be included in #{adapter.timer_metric_names.inspect}, but it was."
   end
 
-  def assert_counter(metric)
+  def assert_counter(metric, opts = { sample_rate: 1, tags: {}})
     assert adapter.counter?(metric),
       "Expected the counter #{metric.inspect} to be included in #{adapter.counter_metric_names.inspect}, but it was not."
   end

--- a/test/support/adapter_test_helpers.rb
+++ b/test/support/adapter_test_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AdapterTestHelpers
   extend ActiveSupport::Concern
 
@@ -13,8 +15,8 @@ module AdapterTestHelpers
   end
 
   def setup_data
-    Post.create(:title => "First")
-    Post.create(:title => "Second")
+    Post.create(title: 'First')
+    Post.create(title: 'Second')
   end
 
   def clean_data
@@ -23,26 +25,26 @@ module AdapterTestHelpers
 
   def assert_timer(metric)
     assert adapter.timer?(metric),
-      "Expected the timer #{metric.inspect} to be included in #{adapter.timer_metric_names.inspect}, but it was not."
+           "Expected the timer #{metric.inspect} to be included in #{adapter.timer_metric_names.inspect}, but it was not."
   end
 
   def refute_timer(metric)
-    assert ! adapter.timer?(metric),
-      "Expected the timer #{metric.inspect} to not be included in #{adapter.timer_metric_names.inspect}, but it was."
+    assert !adapter.timer?(metric),
+           "Expected the timer #{metric.inspect} to not be included in #{adapter.timer_metric_names.inspect}, but it was."
   end
 
-  def assert_counter(metric, opts = { sample_rate: 1, tags: {}})
+  def assert_counter(metric, _opts = { sample_rate: 1, tags: {} })
     assert adapter.counter?(metric),
-      "Expected the counter #{metric.inspect} to be included in #{adapter.counter_metric_names.inspect}, but it was not."
+           "Expected the counter #{metric.inspect} to be included in #{adapter.counter_metric_names.inspect}, but it was not."
   end
 
   def refute_counter(metric)
     refute adapter.counter?(metric),
-      "Expected the counter #{metric.inspect} to not be included in #{adapter.counter_metric_names.inspect}, but it was."
+           "Expected the counter #{metric.inspect} to not be included in #{adapter.counter_metric_names.inspect}, but it was."
   end
 
   def assert_no_counter(metric)
-    assert ! adapter.counter?(metric),
-      "Expected the counter #{metric.inspect} to not be included in adapter.counter_metric_names.inspect}, but it was."
+    assert !adapter.counter?(metric),
+           "Expected the counter #{metric.inspect} to not be included in adapter.counter_metric_names.inspect}, but it was."
   end
 end

--- a/test/support/fake_udp_socket.rb
+++ b/test/support/fake_udp_socket.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 class FakeUdpSocket
   attr_reader :buffer
 
-  TimingRegex = /\:\d+\|ms\Z/
-  CounterRegex = /\:\d+\|c\Z/
+  TimingRegex = /\:\d+\|ms\Z/.freeze
+  CounterRegex = /\:\d+\|c\Z/.freeze
 
   def initialize
     @buffer = []
   end
 
-  def send(message, *rest)
+  def send(message, *_rest)
     @buffer.push message
   end
 

--- a/test/view_instrumentation_test.rb
+++ b/test/view_instrumentation_test.rb
@@ -20,13 +20,13 @@ class ViewInstrumentationTest < ActionController::TestCase
     get :index
 
     assert_response :success
-    assert_timer 'action_view.template.app_views_posts_index_html_erb'
+    assert_timer 'action_view.render.duration.milliseconds', tags: { kind: 'template', path: 'app_views_posts_index_html_erb' }
   end
 
   test 'render_partial' do
     get :index
 
     assert_response :success
-    assert_timer 'action_view.partial.app_views_posts_post_html_erb'
+    assert_timer 'action_view.render.duration.milliseconds', tags: { kind: 'partial', path: 'app_views_posts_post_html_erb' }
   end
 end

--- a/test/view_instrumentation_test.rb
+++ b/test/view_instrumentation_test.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 class ViewInstrumentationTest < ActionController::TestCase
   tests PostsController
@@ -14,17 +16,17 @@ class ViewInstrumentationTest < ActionController::TestCase
     ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
   end
 
-  test "render_template" do
+  test 'render_template' do
     get :index
 
     assert_response :success
-    assert_timer "action_view.template.app_views_posts_index_html_erb"
+    assert_timer 'action_view.template.app_views_posts_index_html_erb'
   end
 
-  test "render_partial" do
+  test 'render_partial' do
     get :index
 
     assert_response :success
-    assert_timer "action_view.partial.app_views_posts_post_html_erb"
+    assert_timer 'action_view.partial.app_views_posts_post_html_erb'
   end
 end


### PR DESCRIPTION
This changes the interface needed to wrap an adapter. It assumes the client can accept a options hash. This allows for this library to pass in additional tags in a structured format, allowing the client to decide how to handle such data.

This removes the need for v0.4.1 branch.